### PR TITLE
fix(client): fix math match

### DIFF
--- a/packages/client/__tests__/math.spec.ts
+++ b/packages/client/__tests__/math.spec.ts
@@ -17,6 +17,10 @@ describe('Should parse inline tex', () => {
     expect(parseMath('Here is a single tex $a$ in the sentence')).toEqual(
       'Here is a single tex <span class="vtex">Tex is not available in preview</span> in the sentence'
     );
+
+    expect(parseMath('$-$')).toEqual(
+      '<span class="vtex">Tex is not available in preview</span>'
+    );
   });
 
   it('Mutiple word', () => {
@@ -35,12 +39,36 @@ describe('Should parse inline tex', () => {
     expect(parseMath('Here is a single tex $a = 1$ in the sentence')).toEqual(
       'Here is a single tex <span class="vtex">Tex is not available in preview</span> in the sentence'
     );
+
+    expect(parseMath('$-\\sqrt{x}$')).toEqual(
+      '<span class="vtex">Tex is not available in preview</span>'
+    );
+
+    expect(parseMath('$-\\sqrt{x}$ is at beginning')).toEqual(
+      '<span class="vtex">Tex is not available in preview</span> is at beginning'
+    );
+
+    expect(parseMath('Here ends a single tex $-\\sqrt{x}$')).toEqual(
+      'Here ends a single tex <span class="vtex">Tex is not available in preview</span>'
+    );
   });
 });
 
 describe('Should parse block tex', () => {
   it('Beginning and ending', () => {
     expect(parseMath('$$\na\n$$')).toEqual(
+      '<p class="vtex">Tex is not available in preview</p>'
+    );
+
+    expect(parseMath('\n$$\na\n$$')).toEqual(
+      '<p class="vtex">Tex is not available in preview</p>'
+    );
+
+    expect(parseMath('$$\na\n$$\n')).toEqual(
+      '<p class="vtex">Tex is not available in preview</p>'
+    );
+
+    expect(parseMath('\n$$\na\n$$\n')).toEqual(
       '<p class="vtex">Tex is not available in preview</p>'
     );
   });
@@ -51,7 +79,31 @@ describe('Should parse block tex', () => {
         '$$\na\n$$\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
       )
     ).toEqual(
-      '<p class="vtex">Tex is not available in preview</p>\n<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>'
+      '<p class="vtex">Tex is not available in preview</p>\nLorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+    );
+  });
+
+  it('Only Ending', () => {
+    expect(parseMath('Lorem ipsum dolor sit amet.\n\n$$\na\n$$')).toEqual(
+      'Lorem ipsum dolor sit amet.\n<p class="vtex">Tex is not available in preview</p>'
+    );
+  });
+
+  it('Inside', () => {
+    expect(
+      parseMath(
+        'Lorem ipsum dolor sit amet\n\n$$\na\n$$\n\nconsectetur adipiscing elit'
+      )
+    ).toEqual(
+      'Lorem ipsum dolor sit amet\n<p class="vtex">Tex is not available in preview</p>\nconsectetur adipiscing elit'
+    );
+
+    expect(
+      parseMath(
+        'Lorem ipsum dolor sit amet\n\n$$\na\n$$\n\n$$-\\sqrt{x}$$\n\nconsectetur adipiscing elit'
+      )
+    ).toEqual(
+      'Lorem ipsum dolor sit amet\n<p class="vtex">Tex is not available in preview</p><p class="vtex">Tex is not available in preview</p>\nconsectetur adipiscing elit'
     );
   });
 });

--- a/packages/client/src/utils/markdown.ts
+++ b/packages/client/src/utils/markdown.ts
@@ -3,8 +3,8 @@ import marked from 'marked';
 
 import type { EmojiMaps } from '../config';
 
-const inlineMathRegExp = /\B\$\b([^\n$]*)\b\$\B/g;
-const blockMathRegExp = /(^|\n\n)\$\$(\n(.+?)\n|(.+?))\$\$(\n\n|$)/g;
+const inlineMathRegExp = /\B\$([^\s$]|[^\s$][^\n$]*[^\s$])\$\B/g;
+const blockMathRegExp = /(^|\n)\$\$(.+?)\$\$(\n|$)/gs;
 
 export const parseEmoji = (text = '', emojiMap: EmojiMaps = {}): string =>
   text.replace(/:(.+?):/g, (placeholder, key: string) =>


### PR DESCRIPTION
修复以下问题：
1. 行内公式无法识别 `$\sqrt{x}$` 等以符号开头 和结尾的内容。
2. 连续的两个行间公式必须空出三行以 `'$$\n\n\n\n$$'` 为间隔，无法空一行以 `'$$\n\n$$'` 为间隔。
3. 当 `2` 发生时如 `‘$$y$$’` 等里面的 `'$y$'` 会被识别为行内公式。
4. 行间公式内无法换行。

此修改会引入一个新的行为：
* `'\n$$'` 和 `'$$\n'` 间的所有字符将被视为 tex