### PR TITLE
feat: Use Libravatar as default avatar (profile picture) provider

### DIFF
--- a/docs/en/guide/client/avatar.md
+++ b/docs/en/guide/client/avatar.md
@@ -1,10 +1,10 @@
 # Avatar Configuration
 
-Waline currently uses [Gravatar][1] as the comment list avatar.
+Waline currently uses [Libravatar][1] as the comment list avatar.
 
-> Thanks for the mirroring service provided by [geekzu](https://cdn.geekzu.org/cached.html), [v2ex](https://v2ex.com).
+Libravatar is a free, open-source avatar provider features federated hosting and Gravatar-compatible APIs.
 
-Users should log in or register by themselves [Gravatar][1], then set or modify their avatar.When commenting, just leave the email address you used when registering in [Gravatar][1].
+Users should log in or register by themselves [Libravatar][1], then set or modify their avatar. When commenting, just leave the email address you used when registering in [Libravatar][1]. Note that if an image is not found in the [Libravatar][1] database and the hash algorithm used was MD5, then Libravatar will first redirect to [Gravatar][2] in case the image exists there.
 
 <!-- more -->
 
@@ -23,24 +23,25 @@ Waline({
 
 ## Available Values
 
-|     Value     |                                                               Demo                                                               | Style                                               |
-| :-----------: | :------------------------------------------------------------------------------------------------------------------------------: | --------------------------------------------------- |
-|     `''`      |                   ![Gravatar official graphics](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40)                   | Gravatar official graphics                          |
-|    `'mp'`     |                  ![Mystic man (a grayhead)](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=mp)                  | Mystic man (a grayhead)                             |
-| `'identicon'` |                 ![Abstract geometry](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=identicon)                  | Abstract geometry                                   |
-| `'monsterid'` |                   ![little monster](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=monsterid)                   | little monster                                      |
-|  `'wavatar'`  |   ![A combination of different faces and backgrounds](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=wavatar)   | A combination of different faces and backgrounds    |
-| `'robohash'`  | ![a generated robot with different colors, faces, etc](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=robohash) | a generated robot with different colors, faces, etc |
-|   `'retro'`   |               ![Eight-pixel retro portrait](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=retro)               | Eight-pixel retro portrait                          |
-|   `'hide'`    |                                                               N/A                                                                | Hidden avatar                                       |
+|     Value     |                                                                  Demo                                                                   | Style                                               |
+| :-----------: | :-------------------------------------------------------------------------------------------------------------------------------------: | --------------------------------------------------- |
+|     `''`      |                  ![Libravatar official graphics](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40)                  | Libravatar official graphics                        |
+|    `'mp'`     |                  ![Mystic man (a grayhead)](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=mp)                  | Mystic man (a grayhead)                             |
+| `'identicon'` |                 ![Abstract geometry](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=identicon)                  | Abstract geometry                                   |
+| `'monsterid'` |                   ![little monster](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=monsterid)                   | little monster                                      |
+|  `'wavatar'`  |   ![A combination of different faces and backgrounds](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=wavatar)   | A combination of different faces and backgrounds    |
+| `'robohash'`  | ![a generated robot with different colors, faces, etc](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=robohash) | a generated robot with different colors, faces, etc |
+|   `'retro'`   |               ![Eight-pixel retro portrait](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=retro)               | Eight-pixel retro portrait                          |
+|   `'hide'`    |                                                                   N/A                                                                   | Hidden avatar                                       |
 
-[1]: http://gravatar.com/
+[1]: https://www.libravatar.org/
+[2]: http://gravatar.com/
 
 ## Attentions
 
 ::: warning
 
-Please note that though email providers such as Google and QQ do not distinguish upper and lower case user names, you still need to ensure that the email address registered by gravatar corresponds to the email address inputed.
+Please note that though email providers such as Google and QQ do not distinguish upper and lower case user names, you still need to ensure that the email address registered on Gravatar corresponds to the email address inputed.
 
 Although most large mail providers in the world do not distinguish case-sensitive email user names, according to RFC 5231, emails are case-sensitive.
 

--- a/docs/en/reference/client.md
+++ b/docs/en/reference/client.md
@@ -167,10 +167,10 @@ number of comments per page.
 ## avatarCDN
 
 - Type: `string`
-- Default: `https://sdn.geekzu.org/avatar/`
+- Default: `https://seccdn.libravatar.org/avatar/`
 - Required: No
 
-Gravatar CDN baseURL.
+Avatar provider baseURL. Supports Gravatar-compatible APIs.
 
 ## avatarForce
 

--- a/docs/guide/client/avatar.md
+++ b/docs/guide/client/avatar.md
@@ -1,10 +1,10 @@
 # 头像配置
 
-Waline 目前使用 [Gravatar][1] 获取评论列表头像。
+Waline 目前使用 [Libravatar][1] 获取评论列表头像。
 
-> 感谢 [极客族](https://cdn.geekzu.org/cached.html)、[v2ex](https://v2ex.com) 提供的镜像服务。
+Libravatar 是自由、开放原始码的头像服务，支持联邦托管并与 [Gravatar][2] 兼容。
 
-用户需要请自行登录或注册 [Gravatar][1]，然后设置或修改自己的头像。评论的时候，留下在 [Gravatar][1] 注册时所使用的邮箱即可。
+用户需要请自行登录或注册 [Libravatar][1]，然后设置或修改自己的头像。评论的时候，留下在 [Libravatar][1] 注册时所使用的邮箱即可。当未能从 Libravatar 查询到头像时，将会自动转为从 [Gravatar][2] 查询。
 
 <!-- more -->
 
@@ -21,24 +21,25 @@ Waline({
 
 ## 可选值
 
-|    参数值     |                                                  表现形式                                                  | 备注                             |
-| :-----------: | :--------------------------------------------------------------------------------------------------------: | -------------------------------- |
-|     `''`      |             ![Gravatar官方图形](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40)             | Gravatar 官方图形                |
-|    `'mp'`     |        ![神秘人(一个灰白头像)](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=mp)         | 神秘人(一个灰白头像)             |
-| `'identicon'` |         ![抽象几何图形](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=identicon)         | 抽象几何图形                     |
-| `'monsterid'` |            ![小怪物](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=monsterid)            | 小怪物                           |
-|  `'wavatar'`  | ![用不同面孔和背景组合生成的头像](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=wavatar) | 用不同面孔和背景组合生成的头像   |
-|   `'retro'`   |         ![八位像素复古头像](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=retro)         | 八位像素复古头像                 |
-| `'robohash'`  |            ![机器人](//sdn.geekzu.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=robohash)             | 一种具有不同颜色、面部等的机器人 |
-|   `'hide'`    |                                                    N/A                                                     | 不显示头像                       |
+|    参数值     |                                                     表现形式                                                      | 备注                             |
+| :-----------: | :---------------------------------------------------------------------------------------------------------------: | -------------------------------- |
+|     `''`      |            ![Libavatar 官方图形](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40)            | Libavatar 官方图形               |
+|    `'mp'`     |        ![神秘人(一个灰白头像)](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=mp)         | 神秘人(一个灰白头像)             |
+| `'identicon'` |         ![抽象几何图形](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=identicon)         | 抽象几何图形                     |
+| `'monsterid'` |            ![小怪物](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=monsterid)            | 小怪物                           |
+|  `'wavatar'`  | ![用不同面孔和背景组合生成的头像](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=wavatar) | 用不同面孔和背景组合生成的头像   |
+|   `'retro'`   |         ![八位像素复古头像](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=retro)         | 八位像素复古头像                 |
+| `'robohash'`  |            ![机器人](//seccdn.libravatar.org/avatar/d41d8cd98f00b204e9800998ecf8427e?s=40&d=robohash)             | 一种具有不同颜色、面部等的机器人 |
+|   `'hide'`    |                                                        N/A                                                        | 不显示头像                       |
 
-[1]: http://cn.gravatar.com/
+[1]: https://www.libravatar.org/
+[2]: http://cn.gravatar.com/
 
 ## 注意事项
 
 ::: warning
 
-请注意，尽管诸如谷歌、QQ 等邮件提供商对电子邮件不区分大小写，但是您仍需要保证 gravatar 注册的邮箱和填入的邮箱地址对应。
+请注意，尽管诸如谷歌、QQ 等邮件提供商对电子邮件不区分大小写，但是您仍需要保证 Gravatar 注册的邮箱和填入的邮箱地址对应。
 
 虽然全球大部分大型邮件提供商均不对电子邮件用户名区分大小写，但是根据 RFC 5231 的规定，电子邮件是区分大小写的。
 

--- a/docs/guide/client/intro.md
+++ b/docs/guide/client/intro.md
@@ -26,7 +26,7 @@ Waline 支持诸多功能，包括登录、头像、多语言、自定义 Emoji�
 
 Waline 官方添加了简体中文、繁体中文、英文和日语的支持，同时你可以在此基础上 [自定义多语言](./i18n.md)
 
-Waline 使用 Gravatar，同时支持你定制默认头像，详见 [头像配置](./avatar.md)。
+Waline 使用 Libravatar [头像配置](./avatar.md)。
 
 你可以很轻松的使用 Waline 提供的预设或自己创建新的预设来自定义评论框内的 Emoji 表情，详见 [自定义 Emoji](./emoji.md)。
 

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -167,10 +167,10 @@ Waline 的服务端地址。
 ## avatarCDN
 
 - 类型: `string`
-- 默认值: `https://sdn.geekzu.org/avatar/`
+- 默认值: `https://seccdn.libravatar.org/avatar/`
 - 必填: 否
 
-设置 Gravatar 头像 CDN 地址。
+设置头像 CDN 地址。可使用任何与 [Gravatar](http://cn.gravatar.com/) API 兼容的服务。
 
 ## avatarForce
 

--- a/packages/admin/src/pages/profile/index.js
+++ b/packages/admin/src/pages/profile/index.js
@@ -84,7 +84,7 @@ export default function () {
                     className="profile-avatar"
                     src={
                       user.avatar ||
-                      `https://sdn.geekzu.org/avatar/${user.mailMd5}?s=220&amp;r=X&amp;d=mm`
+                      `https://seccdn.libravatar.org/avatar/${user.mailMd5}?s=220&amp;r=X&amp;d=mm`
                     }
                   />
                 </a>

--- a/packages/client/src/config/default.ts
+++ b/packages/client/src/config/default.ts
@@ -18,7 +18,7 @@ export const getAvatar = (avatar: Avatar): Avatar =>
 export const getMeta = (meta: Meta[]): Meta[] =>
   meta.filter((item) => availableMeta.includes(item));
 
-export const defaultGravatarCDN = 'https://sdn.geekzu.org/avatar/';
+export const defaultGravatarCDN = 'https://seccdn.libravatar.org/avatar/';
 
 export const defaultLang = 'zh-CN';
 

--- a/packages/client/src/config/options.ts
+++ b/packages/client/src/config/options.ts
@@ -316,7 +316,7 @@ export interface WalineOptions extends DeprecatedValineOptions {
    *
    * Gravatar CDN baseURL
    *
-   * @default 'https://cdn.v2ex.com/gravatar/'
+   * @default 'https://seccdn.libavatar.org/avatar/'
    */
   avatarCDN?: string;
 


### PR DESCRIPTION
Libravatar is a free, open-source avatar provider features federated hosting and Gravatar-compatible APIs. It also redirects to Gravatar automatically when no matching avatar exists in Libravatar.