### PR TITLE
fix: incorrect login redirection when served from subdirectory

### DIFF
--- a/packages/admin/src/App.js
+++ b/packages/admin/src/App.js
@@ -12,11 +12,13 @@ function Access(props) {
 
   useEffect(() => {
     const meta = props.meta || {};
+    const basename = props.basename || '/';
     const emptyUser = !user || !user.email;
     const noPermission =
       emptyUser || (meta.auth ? props.meta.auth !== user.type : false);
     if (emptyUser || noPermission) {
-      return (location.href = '/ui/login?redirect=' + location.pathname);
+      return (location.href =
+        basename + 'ui/login?redirect=' + location.pathname);
     }
   }, [user, props.meta]);
 
@@ -32,7 +34,7 @@ export default function () {
       <Router basename={basepath}>
         <Switch>
           <Route path="/ui" exact>
-            <Access meta={{ auth: 'administrator' }}>
+            <Access meta={{ auth: 'administrator' }} basename={basepath}>
               <ManageComments />
             </Access>
           </Route>


### PR DESCRIPTION
When Waline is served from a sub-directory, login redirection does not handle base URL and gives incorrect redirection:

> ${SITE_URL}/waline => ${SITE_URL}/waline/ui => ${SITE_URL}/ui/login/?redirect=/waline/ui/

This PR should concat the correct path and fix the issue, but more tests could be used. Some other redirection should also be reviewed.