### PR TITLE
fix: redirection URL lacks leading '/' when served from subdirectory

### DIFF
--- a/packages/admin/src/App.js
+++ b/packages/admin/src/App.js
@@ -12,13 +12,13 @@ function Access(props) {
 
   useEffect(() => {
     const meta = props.meta || {};
-    const basename = props.basename || '/';
+    const basename = props.basename || '';
     const emptyUser = !user || !user.email;
     const noPermission =
       emptyUser || (meta.auth ? props.meta.auth !== user.type : false);
     if (emptyUser || noPermission) {
       return (location.href =
-        basename + 'ui/login?redirect=' + location.pathname);
+        basename + '/ui/login?redirect=' + location.pathname);
     }
   }, [user, props.meta]);
 


### PR DESCRIPTION
Starting from 37fd504e6d1d8b18b0f557167626327204ceb52e, redirection will handle paths with subdirectories but lacks a leading slash:

> ${SITE_URL}/waline/ui => ${SITE_URL}/walineui/login/?redirect=/waline/ui/