### PR TITLE
Delete URL links in Qmsg notification

### DIFF
--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -98,7 +98,7 @@ module.exports = class extends think.Service {
     }
 
     const comment = self.comment
-      .replace(/<a href="(.*?)">(.*?)<\/a>/g, '\n[$2] $1\n')
+      .replace(/<a href="(.*?)">(.*?)<\/a>/g, '')
       .replace(/<[^>]+>/g, '');
 
     const data = {
@@ -121,8 +121,8 @@ module.exports = class extends think.Service {
 {{self.comment}}
 邮箱：{{self.mail}}
 状态：{{self.status}} 
-仅供评论预览，查看完整內容：
-{{site.postUrl}}`;
+评论页面：{{self.url}} 
+仅供预览评论，请前往上述页面查看完整內容。`;
 
     return request({
       uri: `https://qmsg.zendee.cn/send/${QMSG_KEY}`,


### PR DESCRIPTION
发送带有链接的消息会被 Qmsg 后台判定为「消息违规：恶意推广」而遭到拦截。据作者介绍「消息内容禁止带url链接」，具体情况见该页评论区：https://zendee.cn/archives/qmsg.html

故删去以下两个部分的代码：

- 提取消息中的链接
- 指向评论所在页面的链接

![iShot](https://user-images.githubusercontent.com/19180725/132142057-1eacdaae-5000-49ab-87be-0ea35f86b50d.png)

