### PR TITLE
三方数据库为mongodb时count无效

### DIFF
--- a/packages/server/src/service/storage/mongodb.js
+++ b/packages/server/src/service/storage/mongodb.js
@@ -94,7 +94,7 @@ module.exports = class extends Base {
       instance.order(`${desc} DESC`);
     }
     if (limit || offset) {
-      instance.limit(offset, limit);
+      instance.limit(offset || 0, limit);
     }
     if (field) {
       instance.field(field);


### PR DESCRIPTION
照mysql的写法修改了一下，在docker里测试有效

instance.limit(offset || 0, limit);