### PR TITLE
fix: 🐛[bug] Comment length out of the preview box

### DIFF
--- a/packages/client/src/styles/card.scss
+++ b/packages/client/src/styles/card.scss
@@ -133,16 +133,13 @@
     }
 
     .vcontent {
+      line-height: 2;
       position: relative;
-
       margin-bottom: 0.75em;
       padding-top: 0.625em;
-
       font-size: 0.875em;
-      line-height: 2;
       word-wrap: break-word;
-      word-break: break-all;
-
+      
       &.expand {
         overflow: hidden;
         max-height: 8em;

--- a/packages/client/src/styles/panel.scss
+++ b/packages/client/src/styles/panel.scss
@@ -191,10 +191,11 @@
     }
 
     .vcontent {
-      min-height: 1.25em;
       padding: 0.25em;
+      min-height: 1.25em;
       border: var(--waline-border);
       border-radius: 0.25em;
+      word-break: break-word;
 
       > *:first-child {
         margin-top: 0;


### PR DESCRIPTION
如下图所示
![image](https://user-images.githubusercontent.com/48512251/133744966-097d600a-e615-4091-8b5a-e6e85bbf7755.png)

虽然不会有人这么做，但这的确是个bug

> word-break
> 如果行末端有个英文单词如 **waline**，但是只剩下容纳两个字母的空间
> &nbsp;&nbsp; break-word: 它会直接跳到下一行显示完整的单词**waline**
> &nbsp;&nbsp; break-all: 它会被截断。第一行末端**wa** ，第二行开头 **line**