### PR TITLE
make 'hyphens' to support more browser

### DIFF
--- a/packages/client/src/styles/panel.scss
+++ b/packages/client/src/styles/panel.scss
@@ -197,6 +197,8 @@
       border-radius: 0.25em;
       word-break: break-word;
       hyphens: auto;
+      -ms-hyphens: auto;
+      -webkit-hyphens: auto
 
       > *:first-child {
         margin-top: 0;


### PR DESCRIPTION
'hyphens' is not supported by Edge, Safari, Safari on iOS. Add '-ms-hyphens' to support Edge 12+. Add '-webkit-hyphens' to support Safari 5.1+, Safari on iOS 4.2+.