### PR TITLE
[FEAT] remove email check regexp

### DIFF
--- a/packages/client/src/components/CommentBox.vue
+++ b/packages/client/src/components/CommentBox.vue
@@ -410,10 +410,7 @@ export default defineComponent({
         }
 
         // check mail
-        if (
-          (requiredMeta.indexOf('mail') > -1 || comment.mail) &&
-          !/^(\w)+([._-]\w+)*@(\w)+((\.\w{2,}){1,3})$/.exec(comment.mail)
-        ) {
+        if (requiredMeta.indexOf('mail') > -1 && !comment.mail) {
           inputRefs.value.mail?.focus();
           return alert(locale.value.mailError);
         }


### PR DESCRIPTION
Email address is very complicated, maybe a simple regexp can't test all legal email. Maybe we can remove it at first.