### PR TITLE
fix issue #831: 对于MONGO_REPLICASET和MONGO_AUTHSOURCE两个选填的环境变量，当没有填写时，不会放入config/adapter.js的mongoOpt内。

### DIFF
--- a/packages/server/src/config/adapter.js
+++ b/packages/server/src/config/adapter.js
@@ -37,10 +37,9 @@ const {
 } = process.env;
 
 let type = 'common';
-let mongoOpt = {
-  replicaSet: MONGO_REPLICASET,
-  authSource: MONGO_AUTHSOURCE,
-};
+let mongoOpt = {};
+if (MONGO_REPLICASET) mongoOpt.replicaSet = MONGO_REPLICASET;
+if (MONGO_AUTHSOURCE) mongoOpt.authSource = MONGO_AUTHSOURCE;
 
 if (MONGO_DB) {
   type = 'mongo';

--- a/packages/server/src/config/adapter.js
+++ b/packages/server/src/config/adapter.js
@@ -37,7 +37,7 @@ const {
 } = process.env;
 
 let type = 'common';
-let mongoOpt = {};
+const mongoOpt = {};
 if (MONGO_REPLICASET) mongoOpt.replicaSet = MONGO_REPLICASET;
 if (MONGO_AUTHSOURCE) mongoOpt.authSource = MONGO_AUTHSOURCE;
 


### PR DESCRIPTION
具体问题详见 #831 。