### PR TITLE
建议当Github OAuth登录的用户没有设置Github昵称时，使用id作为display_name。

### DIFF
--- a/packages/server/src/controller/oauth.js
+++ b/packages/server/src/controller/oauth.js
@@ -77,6 +77,10 @@ module.exports = class extends think.Controller {
       user.email = `${user.id}@mail.${type}`;
     }
 
+    if (!user.name) {
+      user.name = user.id;
+    }
+
     const current = this.ctx.state.userInfo;
     if (!think.isEmpty(current)) {
       const updateData = { [type]: user.id };


### PR DESCRIPTION
否则，现在如果一个通过Github登录的用户没有设置昵称，他的名字就会变成null。

谢谢！