### PR TITLE
fix: 修复客户端无法记住登录问题

### DIFF
--- a/packages/admin/src/store/user.js
+++ b/packages/admin/src/store/user.js
@@ -18,12 +18,14 @@ export const user = {
         return;
       }
       if (window.opener) {
-        let token = window.TOKEN || sessionStorage.getItem('TOKEN');
+        let token = window.TOKEN || localStorage.getItem('TOKEN');
+        let remember = true;
         if (!token) {
-          token = localStorage.getItem('TOKEN');
+          remember = false;
+          token = sessionStorage.getItem('TOKEN');
         }
         window.opener.postMessage(
-          { type: 'userInfo', data: { token, ...user } },
+          { type: 'userInfo', data: { token, remember, ...user } },
           '*'
         );
       }

--- a/packages/admin/src/store/user.js
+++ b/packages/admin/src/store/user.js
@@ -18,12 +18,9 @@ export const user = {
         return;
       }
       if (window.opener) {
-        let token = window.TOKEN || localStorage.getItem('TOKEN');
-        let remember = true;
-        if (!token) {
-          remember = false;
-          token = sessionStorage.getItem('TOKEN');
-        }
+        const localToken = localStorage.getItem('TOKEN');
+        const remember = !!localToken;
+        const token = localToken || window.TOKEN || sessionStorage.getItem('token');
         window.opener.postMessage(
           { type: 'userInfo', data: { token, remember, ...user } },
           '*'


### PR DESCRIPTION
- 如果在评论页面，勾选自动登录，并点击登录，是可以被正确记住的。
- 但如果在管理页面，勾选自动登录，并进行了登录。此时，在评论页面，点击登录按钮，弹窗后，会自动完成登录，但没有将remember属性带过来。这就导致，每次重新打开评论页面，都需要重新点一下登录。