### PR TITLE
fix: 修正pgsql因字段大小写问题导致查询失败的情况

### DIFF
--- a/packages/server/src/service/storage/postgresql.js
+++ b/packages/server/src/service/storage/postgresql.js
@@ -6,12 +6,21 @@ module.exports = class extends MySQL {
   }
 
   async select(...args) {
-    const data = await super.select(...args);
+    const data = await super.select(...args.map(x=>{
+      if (x.field && x.desc) {
+        return {
+          desc: x.desc.toLowerCase(),
+          field: x.field.map(y=>y.toLowerCase()),
+        }
+      }
+      return x
+    }));
+
     return data.map(({ insertedat, createdat, updatedat, ...item }) => {
       const mapFields = {
-        insertedAt: insertedat,
-        createdAt: createdat,
-        updatedAt: updatedat,
+        insertedat: insertedat,
+        createdat: createdat,
+        updatedat: updatedat,
       };
       for (const field in mapFields) {
         if (!mapFields[field]) {


### PR DESCRIPTION
在 #884 中提及的问题，将输入的field&desc内容统一转换为小写。
以较小的改动修复后，我本地测试可用了。对nodejs不了解，请review并给予建议。