### PR TITLE
修改了一下评论管理界面“作者”标签的位置

### DIFF
--- a/packages/admin/src/pages/manage-comments/index.js
+++ b/packages/admin/src/pages/manage-comments/index.js
@@ -388,8 +388,8 @@ export default function () {
                     <thead>
                       <tr>
                         <th> </th>
-                        <th>{t('author')}</th>
                         <th> </th>
+                        <th>{t('author')}</th>
                         <th>{t('content')}</th>
                       </tr>
                     </thead>


### PR DESCRIPTION
从头像一栏移到了用户名一栏，看上去不那么挤了。