### PR TITLE
fix: URL in comment-manager

### DIFF
--- a/packages/admin/src/pages/manage-comments/index.js
+++ b/packages/admin/src/pages/manage-comments/index.js
@@ -570,7 +570,7 @@ export default function () {
                                 <div className="comment-date">
                                   {formatDate(insertedAt)} {t('at')}{' '}
                                   <a
-                                    href={getPostUrl(url)}
+                                    href={`http://${getPostUrl(url)}`}
                                     target="_blank"
                                     rel="noreferrer"
                                   >


### PR DESCRIPTION
修复原文链接会被定向到服务端子目录的问题。