### PR TITLE
docs: WALINE_ADMIN_MODULE_ASSET_URL

### DIFF
--- a/docs/guide/server/notification.md
+++ b/docs/guide/server/notification.md
@@ -150,17 +150,17 @@ Waline 支持为每个平台分别配置您自定义的通知模板，从而实�
 - TG_TEMPLATE:
 
   ````md
-  💬 _[{{site.name}}]({{site.url}}) 有新评论啦_
+  💬 *[{{site.name}}]({{site.url}}) 有新评论啦*
 
-  _{{self.nick}}_ 回复说:
+  *{{self.nick}}* 回复说:
 
   ```
-  {{self.comment-}}
+  {{self.comment}}
   ```
 
-  {{-self.commentLink}}
-  _邮箱_: `{{self.mail}}`
-  _审核_: {{self.status}}
+  {{self.commentLink}}
+  *邮箱*: `{{self.mail}}`
+  *审核*: {{self.status}}
 
   仅供评论预览，点击 [查看完整內容]({{site.postUrl}})
   ````

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -28,12 +28,13 @@ Vercel 需要在 <kbd>Settings</kbd> - <kbd>Environment Variables</kbd> 中进�
 | `IPQPS`             |      | 基于 IP 的评论发布频率限制，单位为秒。默认为 60 秒，设置为 0 不限制                                                     |
 | `SECURE_DOMAINS`    |      | 安全域名配置，支持逗号分隔配置多个域名                                                                                  |
 | `DISABLE_USERAGENT` |      | 是否隐藏评论者的 UA，默认为否                                                                                           |
-| `AKISMET_KEY`       |      | Akismet 反垃圾评论服务 Key（默认开启，不用请设置为 false）                                                              |
+| `AKISMET_KEY`       |      | Akismet 反垃圾评论服务 Key (默认开启，不用请设置为 false)                                                               |
 | `COMMENT_AUDIT`     |      | 评论发布审核开关，配置后建议在 Placehoder 上提供文案提示                                                                |
 | `LOGIN`             |      | 当设置为 `LOGIN=force` 时会要求登录才能评论                                                                             |
 | `AVATAR_PROXY`      |      | 头像的代理地址，默认为 `https://avatar.75cdn.workers.dev`，设置 `false` 关闭代理                                        |
 | `GRAVATAR_STR`      |      | Gravatar 头像的地址，默认为 <span v-pre>`https://seccdn.libravatar.org/avatar/{{mail\|md5}}`</span>，基于 nunjucks 语法 |
 | `OAUTH_URL`         |      | OAuth 第三方登录服务地址，默认为 `https://user.75.team`，也可以使用 [auth](https://github.com/walinejs/auth) 自建       |
+| `WALINE_ADMIN_MODULE_ASSET_URL`         |      | 通过URL自定义后台的 JS 加载脚本，覆盖默认的@waline/admin|
 
 ### Markdown
 
@@ -64,7 +65,7 @@ Vercel 需要在 <kbd>Settings</kbd> - <kbd>Environment Variables</kbd> 中进�
 | `SENDER_EMAIL` | 自定义发送邮件的发件地址                                                            |
 
 :::tip
-可以在[这里](https://github.com/nodemailer/nodemailer/blob/master/lib/well-known/services.json)查看支持的服务商。`SMTP_SERVICE` 和 (`SMTP_HOST`、`SMTP_PORT`）任选其一即可，如果没有在列表中知道对应的 `SMTP_SERVICE` 的话则需要配 `SMTP_HOST` 和 `SMTP_PORT`。
+可以在[这里](https://github.com/nodemailer/nodemailer/blob/master/lib/well-known/services.json)查看支持的服务商。`SMTP_SERVICE` 和 (`SMTP_HOST`、`SMTP_PORT`) 任选其一即可，如果没有在列表中知道对应的 `SMTP_SERVICE` 的话则需要配 `SMTP_HOST` 和 `SMTP_PORT`。
 :::
 
 ### 数据库

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -34,7 +34,6 @@ Vercel 需要在 <kbd>Settings</kbd> - <kbd>Environment Variables</kbd> 中进�
 | `AVATAR_PROXY`      |      | 头像的代理地址，默认为 `https://avatar.75cdn.workers.dev`，设置 `false` 关闭代理                                        |
 | `GRAVATAR_STR`      |      | Gravatar 头像的地址，默认为 <span v-pre>`https://seccdn.libravatar.org/avatar/{{mail\|md5}}`</span>，基于 nunjucks 语法 |
 | `OAUTH_URL`         |      | OAuth 第三方登录服务地址，默认为 `https://user.75.team`，也可以使用 [auth](https://github.com/walinejs/auth) 自建       |
-| `WALINE_ADMIN_MODULE_ASSET_URL`         |      | 通过URL自定义后台的 JS 加载脚本，覆盖默认的@waline/admin|
 
 ### Markdown
 


### PR DESCRIPTION
加入对自定义后台JS加载脚本的描述。
由于在Vercel使用文档中的TG_TEMPLATE报错，故与代码内同步默认TG_TEMPLATE。