### PR TITLE
fix: sticky value error in mysql

### DIFF
--- a/assets/waline.sql
+++ b/assets/waline.sql
@@ -22,7 +22,7 @@ CREATE TABLE `wl_Comment` (
   `nick` varchar(255) DEFAULT NULL,
   `pid` int(11) DEFAULT NULL,
   `rid` int(11) DEFAULT NULL,
-  `sticky` int(11) DEFAULT NULL,
+  `sticky` boolean DEFAULT NULL,
   `status` varchar(50) NOT NULL DEFAULT '',
   `ua` text,
   `url` varchar(255) DEFAULT NULL,

--- a/packages/admin/src/pages/manage-comments/index.js
+++ b/packages/admin/src/pages/manage-comments/index.js
@@ -163,7 +163,7 @@ export default function () {
               cmt.sticky = sticky;
             }
           });
-          await updateComment(comment.objectId, { sticky });
+          await updateComment(comment.objectId, { sticky: sticky ? 1 : 0 });
           setList({ ...list });
         },
       },


### PR DESCRIPTION
修复置顶的问题，修改mysql表结构中sticky的类型为boolean