### PR TITLE
fix: replace cdn.jsdelivr.net/npm/ with unpkg.com/

### DIFF
--- a/docs/src/advanced/ecosystem.md
+++ b/docs/src/advanced/ecosystem.md
@@ -16,7 +16,7 @@ Waline 是经典的前后端分离 Client/Server 架构，提供了较为完善�
   作者 [@MHuiG](https://github.com/MHuiG)，适配 Waline 接口。使用方式如下:
 
   ```html
-  <script src="https://cdn.jsdelivr.net/npm/minivaline/dist/MiniValine.min.js"></script>
+  <script src="https://unpkg.com/minivaline/dist/MiniValine.min.js"></script>
 
   <div id="waline-comments"></div>
   <script>

--- a/docs/src/advanced/faq.md
+++ b/docs/src/advanced/faq.md
@@ -81,10 +81,10 @@ Waline 主要由前端和服务端两部分组成。
 ```html
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/lightgallery@v2/css/lightgallery-bundle.css"
+  href="https://unpkg.com/lightgallery@v2/css/lightgallery-bundle.css"
 />
 <srciprt
-  src="https://cdn.jsdelivr.net/npm/lightgallery@v2/lightgallery.umd.min.js"
+  src="https://unpkg.com/lightgallery@v2/lightgallery.umd.min.js"
 />
 <script>
   document.addEventListener('click', (e) => {
@@ -112,7 +112,7 @@ Waline 主要由前端和服务端两部分组成。
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/gh/cbeyls/slimbox/css/slimbox2.css"
 />
-<script src="https://cdn.jsdelivr.net/npm/jquery@v1/dist/jquery.min.js"></script>
+<script src="https://unpkg.com/jquery@v1/dist/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/cbeyls/slimbox/js/slimbox2.js"></script>
 <script>
   document.addEventListener('click', (e) => {
@@ -137,9 +137,9 @@ Waline 主要由前端和服务端两部分组成。
 ```html
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/lightbox2@v2/dist/css/lightbox.min.css"
+  href="https://unpkg.com/lightbox2@v2/dist/css/lightbox.min.css"
 />
-<script src="https://cdn.jsdelivr.net/npm/lightbox2@v2/dist/js/lightbox-plus-jquery.min.js"></script>
+<script src="https://unpkg.com/lightbox2@v2/dist/js/lightbox-plus-jquery.min.js"></script>
 <script>
   document.addEventListener('click', (e) => {
     const lightbox = new Lightbox();
@@ -166,10 +166,10 @@ Waline 主要由前端和服务端两部分组成。
 在你的 HTML `<head>` 前写入以下内容，其中 `#waline-comment` 是你的 Waline 评论框，需要根据实际场景进行替换。
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@fancyapps/ui/dist/fancybox.umd.js"></script>
+<script src="https://unpkg.com/@fancyapps/ui/dist/fancybox.umd.js"></script>
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@fancyapps/ui/dist/fancybox.css"
+  href="https://unpkg.com/@fancyapps/ui/dist/fancybox.css"
 />
 <script>
   Fancybox.bind('#waline-comment .vcontent img');

--- a/docs/src/en/advanced/ecosystem.md
+++ b/docs/src/en/advanced/ecosystem.md
@@ -16,7 +16,7 @@ Waline is a classic Client/Server architecture, which provides a relatively comp
   By [@MHuiG](https://github.com/MHuiG) , supports Waline API. Usage:
 
   ```html
-  <script src="https://cdn.jsdelivr.net/npm/minivaline/dist/MiniValine.min.js"></script>
+  <script src="https://unpkg.com/minivaline/dist/MiniValine.min.js"></script>
 
   <div id="waline-comments"></div>
   <script>

--- a/docs/src/en/advanced/faq.md
+++ b/docs/src/en/advanced/faq.md
@@ -83,9 +83,9 @@ Insert following code before `<head>` tag in your html content. `#waline-coment`
 ```html
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/lightgallery@v2/css/lightgallery-bundle.css"
+  href="https://unpkg.com/lightgallery@v2/css/lightgallery-bundle.css"
 />
-<script src="https://cdn.jsdelivr.net/npm/lightgallery@v2/lightgallery.umd.min.js"></script>
+<script src="https://unpkg.com/lightgallery@v2/lightgallery.umd.min.js"></script>
 <script>
   document.addEventListener('click', (e) => {
     const imgs = [].slice
@@ -112,7 +112,7 @@ Insert following code before `<head>` tag in your html content. `#waline-coment`
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/gh/cbeyls/slimbox/css/slimbox2.css"
 />
-<script src="https://cdn.jsdelivr.net/npm/jquery@v1/dist/jquery.min.js"></script>
+<script src="https://unpkg.com/jquery@v1/dist/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/gh/cbeyls/slimbox/js/slimbox2.js"></script>
 <script>
   document.addEventListener('click', (e) => {
@@ -137,9 +137,9 @@ Insert following code before `<head>` tag in your html content. `#waline-coment`
 ```html
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/lightbox2@v2/dist/css/lightbox.min.css"
+  href="https://unpkg.com/lightbox2@v2/dist/css/lightbox.min.css"
 />
-<script src="https://cdn.jsdelivr.net/npm/lightbox2@v2/dist/js/lightbox-plus-jquery.min.js"></script>
+<script src="https://unpkg.com/lightbox2@v2/dist/js/lightbox-plus-jquery.min.js"></script>
 <script>
   document.addEventListener('click', (e) => {
     const lightbox = new Lightbox();
@@ -166,10 +166,10 @@ Insert following code before `<head>` tag in your html content. `#waline-coment`
 Insert following code before `<head>` tag in your html content. `#waline-coment` is your Waline comment element selector, you need replace it by yourself.
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@fancyapps/ui/dist/fancybox.umd.js"></script>
+<script src="https://unpkg.com/@fancyapps/ui/dist/fancybox.umd.js"></script>
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/@fancyapps/ui/dist/fancybox.css"
+  href="https://unpkg.com/@fancyapps/ui/dist/fancybox.css"
 />
 <script>
   Fancybox.bind('#waline-comment .vcontent img');

--- a/docs/src/en/guide/client/import.md
+++ b/docs/src/en/guide/client/import.md
@@ -7,7 +7,7 @@ Waline provides several versions of client files. You can introduce Waline in a 
 
 ## Via CDN
 
-Recommend to use [jsdelivr](https://cdn.jsdelivr.net/npm/@waline/client/).
+Recommend to use [jsdelivr](https://unpkg.com/@waline/client/).
 
 :::: code-group
 
@@ -15,11 +15,11 @@ Recommend to use [jsdelivr](https://cdn.jsdelivr.net/npm/@waline/client/).
 
 ```html
 <!-- Scripts -->
-<script src="//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js"></script>
+<script src="//unpkg.com/@waline/client@v2/dist/waline.js"></script>
 <!-- Styles -->
 <link
   rel="stylesheet"
-  href="//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css"
+  href="//unpkg.com/@waline/client@v2/dist/waline.css"
 />
 ```
 
@@ -27,7 +27,7 @@ Recommend to use [jsdelivr](https://cdn.jsdelivr.net/npm/@waline/client/).
 
 ```html
 <!-- Pageview -->
-<script src="//cdn.jsdelivr.net/npm/@waline/client/dist/pageview.js"></script>
+<script src="//unpkg.com/@waline/client/dist/pageview.js"></script>
 ```
 
 :::
@@ -40,7 +40,7 @@ For CDN links, if you don't specify a version number, it will be latest version,
 
 ```html
 <!-- You need to modify and replace `next` with the version number you want -->
-<script src="//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js"></script>
+<script src="//unpkg.com/@waline/client@v2/dist/waline.js"></script>
 ```
 
 :::

--- a/docs/src/en/guide/client/pageview.md
+++ b/docs/src/en/guide/client/pageview.md
@@ -58,7 +58,7 @@ If you only need to use the pageview statistics function, you can import the pag
     <span class="waline-pageview-count" data-path="/" />
   </li>
 </ul>
-<script src="//cdn.jsdelivr.net/npm/@waline/client/dist/pageview.js"></script>
+<script src="//unpkg.com/@waline/client/dist/pageview.js"></script>
 <script>
   Waline.pageviewCount({
     serverURL: '<YOUR_SERVER_URL>',

--- a/docs/src/en/guide/get-started.md
+++ b/docs/src/en/guide/get-started.md
@@ -82,8 +82,8 @@ Make the following settings on your web page:
 
 1. Use CDN to import Waline:
 
-   - `//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js`.
-   - `//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css`.
+   - `//unpkg.com/@waline/client@v2/dist/waline.js`.
+   - `//unpkg.com/@waline/client@v2/dist/waline.css`.
 
 1. Create a `<script>` tag and initialize with `Waline.init()` while passing in the necessary `el` and `serverURL` options.
 
@@ -93,10 +93,10 @@ Make the following settings on your web page:
    ```html {3-7,12-18}:line-numbers
    <head>
      <!-- ... -->
-     <script src="//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js"></script>
+     <script src="//unpkg.com/@waline/client@v2/dist/waline.js"></script>
      <link
        rel="stylesheet"
-       href="//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css"
+       href="//unpkg.com/@waline/client@v2/dist/waline.css"
      />
      <!-- ... -->
    </head>

--- a/docs/src/en/migration/client.md
+++ b/docs/src/en/migration/client.md
@@ -18,9 +18,9 @@ We changed Waline's default export to `init` named export, and to make Waline SS
 In most cases, this just means the following changes:
 
 ```diff
-- <script src='//cdn.jsdelivr.net/npm/@waline/client'></script>
-+ <script src='//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js'></script>
-+ <link href='//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css' rel='stylesheet' />
+- <script src='//unpkg.com/@waline/client'></script>
++ <script src='//unpkg.com/@waline/client@v2/dist/waline.js'></script>
++ <link href='//unpkg.com/@waline/client@v2/dist/waline.css' rel='stylesheet' />
 
   <script>
 -  Waline({

--- a/docs/src/en/migration/valine.md
+++ b/docs/src/en/migration/valine.md
@@ -10,8 +10,8 @@ Since Waline completely reuses Valine's data structure in storage, migrating fro
 
    ```diff
    - <script src='//unpkg.com/valine/dist/Valine.min.js'></script>
-   + <script src='//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js'></script>
-   + <link href='//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css' rel='stylesheet' />
+   + <script src='//unpkg.com/@waline/client@v2/dist/waline.js'></script>
+   + <link href='//unpkg.com/@waline/client@v2/dist/waline.css' rel='stylesheet' />
 
      <script>
    -  new Valine({

--- a/docs/src/en/reference/component.md
+++ b/docs/src/en/reference/component.md
@@ -165,16 +165,16 @@ A demo using prismjs to highlight code blocks.
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Waline highlighter demo</title>
-    <script src="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.js"></script>
+    <script src="https://unpkg.com/@waline/client@v1/dist/waline.js"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.css"
+      href="https://unpkg.com/@waline/client@v1/dist/waline.css"
     />
-    <script src="https://cdn.jsdelivr.net/npm/prismjs@v1" data-manual></script>
-    <script src="https://cdn.jsdelivr.net/npm/prismjs@v1/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://unpkg.com/prismjs@v1" data-manual></script>
+    <script src="https://unpkg.com/prismjs@v1/plugins/autoloader/prism-autoloader.min.js"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/prismjs@v1/themes/prism-tomorrow.min.css"
+      href="https://unpkg.com/prismjs@v1/themes/prism-tomorrow.min.css"
     />
   </head>
   <body>
@@ -231,15 +231,15 @@ You can import $\TeX$ renderer to provide preview feature. We recommend you to u
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Waline highlighter 案例</title>
-    <script src="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.js"></script>
+    <script src="https://unpkg.com/@waline/client@v1/dist/waline.js"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.css"
+      href="https://unpkg.com/@waline/client@v1/dist/waline.css"
     />
-    <script src="https://cdn.jsdelivr.net/npm/katex@v0.15"></script>
+    <script src="https://unpkg.com/katex@v0.15"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/katex@v0.15/dist/katex.min.css"
+      href="https://unpkg.com/katex@v0.15/dist/katex.min.css"
     />
   </head>
   <body>
@@ -272,12 +272,12 @@ You can import $\TeX$ renderer to provide preview feature. We recommend you to u
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Waline highlighter 案例</title>
-    <script src="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.js"></script>
+    <script src="https://unpkg.com/@waline/client@v1/dist/waline.js"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.css"
+      href="https://unpkg.com/@waline/client@v1/dist/waline.css"
     />
-    <script src="https://cdn.jsdelivr.net/npm/mathjax@v3/es5/tex-svg.js"></script>
+    <script src="https://unpkg.com/mathjax@v3/es5/tex-svg.js"></script>
   </head>
   <body>
     <div id="waline" style="max-width: 800px; margin: 0 auto"></div>

--- a/docs/src/guide/client/import.md
+++ b/docs/src/guide/client/import.md
@@ -9,7 +9,7 @@ Waline 提供多种版本的客户端文件。你可以通过多种方式引入 
 
 ## 通过 CDN
 
-推荐使用 [jsdelivr](https://cdn.jsdelivr.net/npm/@waline/client)。
+推荐使用 [jsdelivr](https://unpkg.com/@waline/client)。
 
 :::: code-group
 
@@ -17,11 +17,11 @@ Waline 提供多种版本的客户端文件。你可以通过多种方式引入 
 
 ```html
 <!-- 脚本文件 -->
-<script src="//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js"></script>
+<script src="//unpkg.com/@waline/client@v2/dist/waline.js"></script>
 <!-- 样式文件 -->
 <link
   rel="stylesheet"
-  href="//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css"
+  href="//unpkg.com/@waline/client@v2/dist/waline.css"
 />
 ```
 
@@ -31,7 +31,7 @@ Waline 提供多种版本的客户端文件。你可以通过多种方式引入 
 
 ```html
 <!-- 浏览量 -->
-<script src="//cdn.jsdelivr.net/npm/@waline/client/dist/pageview.js"></script>
+<script src="//unpkg.com/@waline/client/dist/pageview.js"></script>
 ```
 
 :::
@@ -44,7 +44,7 @@ Waline 提供多种版本的客户端文件。你可以通过多种方式引入 
 
 ```html
 <!-- 你需要自行修改替换 `next` 为你想要的版本号 -->
-<script src="//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js"></script>
+<script src="//unpkg.com/@waline/client@v2/dist/waline.js"></script>
 ```
 
 :::

--- a/docs/src/guide/client/pageview.md
+++ b/docs/src/guide/client/pageview.md
@@ -57,7 +57,7 @@ Waline 会自动查找页面中 `class` 值为 `waline-pageview-count` 的元素
     <span class="waline-pageview-count" data-path="/" />
   </li>
 </ul>
-<script src="//cdn.jsdelivr.net/npm/@waline/client/dist/pageview.js"></script>
+<script src="//unpkg.com/@waline/client/dist/pageview.js"></script>
 <script>
   Waline.pageviewCount({
     serverURL: '<YOUR_SERVER_URL>',

--- a/docs/src/guide/get-started.md
+++ b/docs/src/guide/get-started.md
@@ -101,8 +101,8 @@ icon: creative
 
 1. 使用 CDN 引入 Waline:
 
-   - `//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js`。
-   - `//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css`。
+   - `//unpkg.com/@waline/client@v2/dist/waline.js`。
+   - `//unpkg.com/@waline/client@v2/dist/waline.css`。
 
 1. 创建 `<script>` 标签使用 `Waline.init()` 初始化，并传入必要的 `el` 与 `serverURL` 选项。
 
@@ -112,10 +112,10 @@ icon: creative
    ```html {3-7,12-18}:line-numbers
    <head>
      <!-- ... -->
-     <script src="//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js"></script>
+     <script src="//unpkg.com/@waline/client@v2/dist/waline.js"></script>
      <link
        rel="stylesheet"
-       href="//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css"
+       href="//unpkg.com/@waline/client@v2/dist/waline.css"
      />
      <!-- ... -->
    </head>

--- a/docs/src/migration/client.md
+++ b/docs/src/migration/client.md
@@ -18,9 +18,9 @@ icon: migration
 在大多数情况下，这只意味着下列更改:
 
 ```diff
-- <script src='//cdn.jsdelivr.net/npm/@waline/client'></script>
-+ <script src='//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js'></script>
-+ <link href='//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css' rel='stylesheet' />
+- <script src='//unpkg.com/@waline/client'></script>
++ <script src='//unpkg.com/@waline/client@v2/dist/waline.js'></script>
++ <link href='//unpkg.com/@waline/client@v2/dist/waline.css' rel='stylesheet' />
 
   <script>
 -  Waline({

--- a/docs/src/migration/valine.md
+++ b/docs/src/migration/valine.md
@@ -16,8 +16,8 @@ icon: valine
 
    ```diff
    - <script src='//unpkg.com/valine/dist/Valine.min.js'></script>
-   + <script src='//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js'></script>
-   + <link href='//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css' rel='stylesheet' />
+   + <script src='//unpkg.com/@waline/client@v2/dist/waline.js'></script>
+   + <link href='//unpkg.com/@waline/client@v2/dist/waline.css' rel='stylesheet' />
 
      <script>
    -  new Valine({

--- a/docs/src/reference/component.md
+++ b/docs/src/reference/component.md
@@ -165,16 +165,16 @@ Waline 的服务端地址。
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Waline highlighter 案例</title>
-    <script src="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.js"></script>
+    <script src="https://unpkg.com/@waline/client@v1/dist/waline.js"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.css"
+      href="https://unpkg.com/@waline/client@v1/dist/waline.css"
     />
-    <script src="https://cdn.jsdelivr.net/npm/prismjs@v1" data-manual></script>
-    <script src="https://cdn.jsdelivr.net/npm/prismjs@v1/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://unpkg.com/prismjs@v1" data-manual></script>
+    <script src="https://unpkg.com/prismjs@v1/plugins/autoloader/prism-autoloader.min.js"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/prismjs@v1/themes/prism-tomorrow.min.css"
+      href="https://unpkg.com/prismjs@v1/themes/prism-tomorrow.min.css"
     />
   </head>
   <body>
@@ -230,15 +230,15 @@ Waline 的服务端地址。
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Waline highlighter 案例</title>
-    <script src="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.js"></script>
+    <script src="https://unpkg.com/@waline/client@v1/dist/waline.js"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.css"
+      href="https://unpkg.com/@waline/client@v1/dist/waline.css"
     />
-    <script src="https://cdn.jsdelivr.net/npm/katex@v0.15"></script>
+    <script src="https://unpkg.com/katex@v0.15"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/katex@v0.15/dist/katex.min.css"
+      href="https://unpkg.com/katex@v0.15/dist/katex.min.css"
     />
   </head>
   <body>
@@ -271,12 +271,12 @@ Waline 的服务端地址。
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Waline highlighter 案例</title>
-    <script src="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.js"></script>
+    <script src="https://unpkg.com/@waline/client@v1/dist/waline.js"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@waline/client@v1/dist/waline.css"
+      href="https://unpkg.com/@waline/client@v1/dist/waline.css"
     />
-    <script src="https://cdn.jsdelivr.net/npm/mathjax@v3/es5/tex-svg.js"></script>
+    <script src="https://unpkg.com/mathjax@v3/es5/tex-svg.js"></script>
   </head>
   <body>
     <div id="waline" style="max-width: 800px; margin: 0 auto"></div>

--- a/packages/client/__tests__/highlighter.html
+++ b/packages/client/__tests__/highlighter.html
@@ -6,11 +6,11 @@
     <title>Waline highlighter demo</title>
     <script src="../dist/waline.js"></script>
     <link rel="stylesheet" href="../dist/waline.css" />
-    <script src="https://cdn.jsdelivr.net/npm/prismjs@v1" data-manual></script>
-    <script src="https://cdn.jsdelivr.net/npm/prismjs@v1/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://unpkg.com/prismjs@v1" data-manual></script>
+    <script src="https://unpkg.com/prismjs@v1/plugins/autoloader/prism-autoloader.min.js"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/prismjs@v1/themes/prism-tomorrow.min.css"
+      href="https://unpkg.com/prismjs@v1/themes/prism-tomorrow.min.css"
     />
   </head>
   <body>

--- a/packages/client/__tests__/katex.html
+++ b/packages/client/__tests__/katex.html
@@ -6,10 +6,10 @@
     <title>Waline KaTeX demo</title>
     <script src="../dist/waline.js"></script>
     <link rel="stylesheet" href="../dist/waline.css" />
-    <script src="https://cdn.jsdelivr.net/npm/katex@v0.15"></script>
+    <script src="https://unpkg.com/katex@v0.15"></script>
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/katex@v0.15/dist/katex.min.css"
+      href="https://unpkg.com/katex@v0.15/dist/katex.min.css"
     />
   </head>
   <body>

--- a/packages/client/__tests__/mathjax.html
+++ b/packages/client/__tests__/mathjax.html
@@ -6,7 +6,7 @@
     <title>Waline MathJax demo</title>
     <script src="../dist/waline.js"></script>
     <link rel="stylesheet" href="../dist/waline.css" />
-    <script src="https://cdn.jsdelivr.net/npm/mathjax@v3/es5/tex-svg.js"></script>
+    <script src="https://unpkg.com/mathjax@v3/es5/tex-svg.js"></script>
   </head>
   <body>
     <div id="waline" style="max-width: 800px; margin: 0 auto"></div>

--- a/packages/client/__tests__/wordCount.spec.ts
+++ b/packages/client/__tests__/wordCount.spec.ts
@@ -73,7 +73,7 @@ describe('Words test', () => {
     ]);
 
     expect(getWordNumber(linkAddress)).toEqual(8);
-    expect(getWordNumber(linkMarkdown)).toEqual(15);
+    expect(getWordNumber(linkMarkdown)).toEqual(13);
     expect(getWordNumber(imageMarkdown)).toEqual(9);
   });
 

--- a/packages/client/__tests__/wordCount.spec.ts
+++ b/packages/client/__tests__/wordCount.spec.ts
@@ -72,7 +72,7 @@ describe('Words test', () => {
       'js',
     ]);
 
-    expect(getWordNumber(linkAddress)).toEqual(10);
+    expect(getWordNumber(linkAddress)).toEqual(8);
     expect(getWordNumber(linkMarkdown)).toEqual(15);
     expect(getWordNumber(imageMarkdown)).toEqual(9);
   });
@@ -146,6 +146,6 @@ describe('Words test', () => {
       'body',
     ]);
 
-    expect(getWordNumber(codeBlock)).toEqual(44);
+    expect(getWordNumber(codeBlock)).toEqual(40);
   });
 });

--- a/packages/client/__tests__/wordCount.spec.ts
+++ b/packages/client/__tests__/wordCount.spec.ts
@@ -54,7 +54,7 @@ describe('Words test', () => {
 
   it('Addtional counts with Markdown links and images', () => {
     const linkAddress =
-      '//cdn.jsdelivr.net/npm/@waline/client/dist/Waline.min.js';
+      '//unpkg.com/@waline/client/dist/Waline.min.js';
     const linkMarkdown = `You can found Waline [here](${linkAddress}).`;
     const imageMarkdown = `Here is a image.\n\n![Alt](https://a/fake/link)`;
 
@@ -85,10 +85,10 @@ describe('Words test', () => {
 \`\`\`html
 <head>
   <!-- ... -->
-  <script src="//cdn.jsdelivr.net/npm/@waline/client"></script>
+  <script src="//unpkg.com/@waline/client"></script>
   <link
     rel="stylesheet"
-    href="//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css"
+    href="//unpkg.com/@waline/client@v2/dist/waline.css"
   />
   <!-- ... -->
 </head>

--- a/packages/client/__tests__/wordCount.spec.ts
+++ b/packages/client/__tests__/wordCount.spec.ts
@@ -53,8 +53,7 @@ describe('Words test', () => {
   });
 
   it('Addtional counts with Markdown links and images', () => {
-    const linkAddress =
-      '//unpkg.com/@waline/client/dist/Waline.min.js';
+    const linkAddress = '//unpkg.com/@waline/client/dist/Waline.min.js';
     const linkMarkdown = `You can found Waline [here](${linkAddress}).`;
     const imageMarkdown = `Here is a image.\n\n![Alt](https://a/fake/link)`;
 
@@ -63,10 +62,8 @@ describe('Words test', () => {
       .filter((word) => word);
 
     expect(linkWords).toEqual([
-      'cdn',
-      'jsdelivr',
-      'net',
-      'npm',
+      'unpkg',
+      'com',
       'waline',
       'client',
       'dist',
@@ -113,20 +110,16 @@ describe('Words test', () => {
       'html',
       'head',
       'script src',
-      'cdn',
-      'jsdelivr',
-      'net',
-      'npm',
+      'unpkg',
+      'com',
       'waline',
       'client',
       'script',
       'link\n    rel',
       'stylesheet',
       'href',
-      'cdn',
-      'jsdelivr',
-      'net',
-      'npm',
+      'unpkg',
+      'com',
       'waline',
       'client',
       'v2',

--- a/packages/client/src/entrys/legacy.ts
+++ b/packages/client/src/entrys/legacy.ts
@@ -18,7 +18,7 @@ warning(
 const link = document.createElement('link');
 
 link.rel = 'stylesheet';
-link.href = '//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css';
+link.href = '//unpkg.com/@waline/client@v2/dist/waline.css';
 
 document.head.appendChild(link);
 

--- a/packages/hexo-next/waline.njk
+++ b/packages/hexo-next/waline.njk
@@ -3,7 +3,7 @@
 }, config.waline, {
   el: '#waline',
   comment: true,
-  libUrl: config.waline.libUrl | default('https://cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js', true),
+  libUrl: config.waline.libUrl | default('https://unpkg.com/@waline/client@v2/dist/waline.js', true),
   path: url_for(page.path) | replace(r/\/index\.html$/, '/')
 }) }}
 <link rel="stylesheet" href="{{ config.waline.cssUrl }}">

--- a/packages/server/src/controller/index.js
+++ b/packages/server/src/controller/index.js
@@ -13,8 +13,8 @@ module.exports = class extends think.Controller {
     </head>
     <body>
       <div id="waline" style="max-width: 800px;margin: 0 auto;"></div>
-      <script src="https://cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.js"></script>
-      <link href='//cdn.jsdelivr.net/npm/@waline/client@v2/dist/waline.css' rel='stylesheet' />
+      <script src="https://unpkg.com/@waline/client@v2/dist/waline.js"></script>
+      <link href='//unpkg.com/@waline/client@v2/dist/waline.css' rel='stylesheet' />
       <script>
         console.log(
           '%c @waline/server %c v${version} ',

--- a/packages/server/src/middleware/dashboard.js
+++ b/packages/server/src/middleware/dashboard.js
@@ -15,7 +15,7 @@ module.exports = function () {
     </script>
     <script src="${
       process.env.WALINE_ADMIN_MODULE_ASSET_URL ||
-      'https://cdn.jsdelivr.net/npm/@waline/admin'
+      'https://unpkg.com/@waline/admin'
     }"></script>
   </body>
 </html>`;


### PR DESCRIPTION
jsdelivr has been blocked in China. See jsdelivr/jsdelivr#18392.
Npm packages can be migrated to unpkg.
However, there are still some cdn.jsdelivr.net/gh/ urls. Unpkg doesn't support it. They may need to be published as npm packages.