### PR TITLE
fix: 设置 max-height 和 max-width 以减少关闭的 GIF 面板对页面布局的影响

### DIFF
--- a/packages/client/src/styles/gif.scss
+++ b/packages/client/src/styles/gif.scss
@@ -15,6 +15,8 @@
 
     opacity: 0;
     visibility: hidden;
+    max-width: 0px;
+    max-height: 0px;
 
     transition: transform 0.2s ease-out, opacity 0.2s ease-out;
     transform: scale(0.9, 0.9);
@@ -24,6 +26,8 @@
       opacity: 1;
       visibility: visible;
       transform: none;
+      max-width: unset;
+      max-height: unset;
     }
 
     input {


### PR DESCRIPTION
**在手机浏览时**，waline 新增加的 GIF 表情包功能的面板会**严重影响网页的布局**，导致页面中产生大量空白。 
桌面平台上若将 waline 放在页尾且评论较少时，开启面板后关闭，偶现类似问题，但影响不大。
使用 max-height 和 max-width 即可减少面板关闭时对页面布局的影响。 
![1](https://user-images.githubusercontent.com/24828354/168972206-39ed54f9-f768-458d-8bcc-00cd2190f144.png)
