### PR TITLE
ci: use packageManager for pnpm

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -9,10 +9,8 @@ jobs:
   deploy-docs:
     strategy:
       matrix:
-        node-version:
-          - 16
-        os:
-          - ubuntu-latest
+        node-version: [16]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -23,7 +21,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
           run_install: true
 
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -20,14 +20,15 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
-        with:
-          run_install: true
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Build Client
         run: pnpm client:build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,8 @@ jobs:
   build-test:
     strategy:
       matrix:
-        node-version:
-          - 14
-          - 16
-          - 18
-        os:
-          - ubuntu-latest
+        node-version: [16]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -24,7 +20,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
           run_install: true
 
       - name: Use Node.js ${{ matrix.node-version }}
@@ -49,7 +44,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
           run_install: true
 
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,15 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
-        with:
-          run_install: true
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Package Build Test
         run: pnpm build
@@ -43,14 +44,15 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2
-        with:
-          run_install: true
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Linter test
         run: pnpm lint

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "waline",
   "version": "0.0.1",
   "private": true,
+  "packageManager": "pnpm@7.1.3",
   "scripts": {
     "admin:analyze": "npm --dir=packages/admin analyze",
     "admin:build": "pnpm --dir=packages/admin build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12604,6 +12604,9 @@ packages:
     hasBin: true
     peerDependencies:
       typescript: '>=2.7'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
       arg: 4.1.3
       diff: 4.0.2


### PR DESCRIPTION
- use `packageManager` for pnpm
- i think we just need `lts/16` to test, because the node version has no effect on the user.
- use `--frozen-lockfile` to ensure version & use cache