### PR TITLE
在服务端加入“必填项”的检查

### DIFF
--- a/packages/server/src/controller/comment.js
+++ b/packages/server/src/controller/comment.js
@@ -478,6 +478,18 @@ module.exports = class extends BaseRest {
 
       think.logger.debug(`Comment IP ${data.ip} check OK!`);
 
+      /* check required metadata in environment variable */
+      const { REQUIRED_META = 'comment' } = process.env
+      var metap = REQUIRED_META.replaceAll(' ', '').split(',')
+      
+      for(var a = 0, len = metap.length; a < len; a++){
+        if(data[metap[a]] == null || data[metap[a]].length == 0){
+          think.logger.debug(`Lost Metadata ${metap[a]}`)
+          return this.fail(`Metadata ${metap[a]} Required`)
+        }
+      }
+      think.logger.debug(`Comment Metadata check OK!`)
+      
       /** Duplicate content detect */
       const duplicate = await this.modelInstance.select({
         url,


### PR DESCRIPTION
我来PR了（￣︶￣）↗　

(于481行)

以下所称的metadata为comment对象中的子类，原因是早期的waline客户端存在一个叫作`requiredMeta`的参数可以配置评论的必填项目。

通过读取`REQUIRED_META`环境变量（内容为`comment`的各个元素，多个元素以逗号分隔，如`nick, mail`），在服务端检查必填项目，以防范别有用心者绕过客户端通过API刷评论。

