### PR TITLE
fix: fix sqlite date field

### DIFF
--- a/packages/server/src/service/storage/mysql.js
+++ b/packages/server/src/service/storage/mysql.js
@@ -78,6 +78,11 @@ module.exports = class extends Base {
       data.id = data.objectId;
       delete data.objectId;
     }
+    const date = new Date();
+    if (!data.createdAt)
+      data.createdAt = date;
+    if (!data.updatedAt)
+      data.updatedAt = date;
 
     const instance = this.model(this.tableName);
     const id = await instance.add(data);


### PR DESCRIPTION
修复 #1272 
问题出在think-model-abstract的parseData函数 [ref](https://github.com/thinkjs/think-model-abstract/blob/adb8ceb7a47aa6efc666b855e1a161a0f1f3f2dd/lib/schema.js#L56)
对于 `createdAt` 和 `updatedAt`，执行到此处时 `schema[key].default` 值为string类型的 `datetime('now', 'localtime')`，后续isFunction判断为假然后插入的时候就是`datetime('now', 'localtime')`而不是预期的时间了。

完全修起来比较麻烦要改think-model-abstract实现sqlite内置函数，可能会影响到thinkjs框架。这里取了个巧手动赋值一下日期。

修复前
<img width="352" alt="image" src="https://user-images.githubusercontent.com/16700613/183975131-cc83809a-a6b2-4a61-853a-18a119a0ddbf.png">
修复后
<img width="290" alt="image" src="https://user-images.githubusercontent.com/16700613/183975169-c73c0be1-ed5b-48bd-a250-13447177eb08.png">
