### PR TITLE
丰富OAUTH_URL的说明

### DIFF
--- a/docs/src/reference/env.md
+++ b/docs/src/reference/env.md
@@ -196,6 +196,6 @@ SMTP 的用户名通常均支持用户的完整邮箱，而密码大多同邮箱
 
 | 环境变量名称                    | 默认值                      | 备注                                                                         |
 | ------------------------------- | --------------------------- | ---------------------------------------------------------------------------- |
-| `OAUTH_URL`                     | `https://oauth.lithub.cc`   | OAuth 第三方登录服务地址，可以 [自建 auth](https://github.com/walinejs/auth) |
+| `OAUTH_URL`                     | `https://oauth.lithub.cc`   | OAuth 第三方登录服务地址，可以 [自建 auth](https://github.com/walinejs/auth) 这是能让用户使用Github, Twitter 推特, Facebook 脸书, Google 谷歌, 微博 Weibo 等第三方账户登录最简单的方式.|
 | `WEBHOOK`                       |                             | 评论成功后会向 WEBHOOK 配置的地址发送一条 POST 请求                          |
 | `WALINE_ADMIN_MODULE_ASSET_URL` | `//unpkg.com/@waline/admin` | Waline admin 地址                                                            |

--- a/docs/src/reference/env.md
+++ b/docs/src/reference/env.md
@@ -196,6 +196,6 @@ SMTP 的用户名通常均支持用户的完整邮箱，而密码大多同邮箱
 
 | 环境变量名称                    | 默认值                      | 备注                                                                         |
 | ------------------------------- | --------------------------- | ---------------------------------------------------------------------------- |
-| `OAUTH_URL`                     | `https://oauth.lithub.cc`   | OAuth 第三方登录服务地址，可以 [自建 auth](https://github.com/walinejs/auth) 这是能让用户使用GitHub, Twitter, Facebook, Google, 微博等第三方账户登录最简单的方式.|
+| `OAUTH_URL`                     | `https://oauth.lithub.cc`   | OAuth 第三方登录服务地址，可以 [自建 auth](https://github.com/walinejs/auth) 这是能让用户使用 GitHub, Twitter, Facebook, Google, 微博等第三方账户登录最简单的方式。|
 | `WEBHOOK`                       |                             | 评论成功后会向 WEBHOOK 配置的地址发送一条 POST 请求                          |
 | `WALINE_ADMIN_MODULE_ASSET_URL` | `//unpkg.com/@waline/admin` | Waline admin 地址                                                            |

--- a/docs/src/reference/env.md
+++ b/docs/src/reference/env.md
@@ -196,6 +196,6 @@ SMTP 的用户名通常均支持用户的完整邮箱，而密码大多同邮箱
 
 | 环境变量名称                    | 默认值                      | 备注                                                                         |
 | ------------------------------- | --------------------------- | ---------------------------------------------------------------------------- |
-| `OAUTH_URL`                     | `https://oauth.lithub.cc`   | OAuth 第三方登录服务地址，可以 [自建 auth](https://github.com/walinejs/auth) 这是能让用户使用Github, Twitter 推特, Facebook 脸书, Google 谷歌, 微博 Weibo 等第三方账户登录最简单的方式.|
+| `OAUTH_URL`                     | `https://oauth.lithub.cc`   | OAuth 第三方登录服务地址，可以 [自建 auth](https://github.com/walinejs/auth) 这是能让用户使用GitHub, Twitter, Facebook, Google, 微博等第三方账户登录最简单的方式.|
 | `WEBHOOK`                       |                             | 评论成功后会向 WEBHOOK 配置的地址发送一条 POST 请求                          |
 | `WALINE_ADMIN_MODULE_ASSET_URL` | `//unpkg.com/@waline/admin` | Waline admin 地址                                                            |


### PR DESCRIPTION
页面内想要找到相关登陆的线索, 直觉上可能是搜索相应的供应商的名称而非一下就是oath