### PR TITLE
[FEAT] Default language switch

### DIFF
--- a/packages/client/src/comment.ts
+++ b/packages/client/src/comment.ts
@@ -33,7 +33,7 @@ export interface WalineCommentCountOptions {
    *
    * Language of error message
    *
-   * @default 'zh-CN'
+   * @default navigator.language
    */
   lang?: string;
 }
@@ -42,7 +42,7 @@ export const commentCount = ({
   serverURL,
   path = window.location.pathname,
   selector = '.waline-comment-count',
-  lang = 'zh-CN',
+  lang = navigator.language,
 }: WalineCommentCountOptions): WalineAbort => {
   const controller = new AbortController();
 

--- a/packages/client/src/config/default.ts
+++ b/packages/client/src/config/default.ts
@@ -15,7 +15,7 @@ export const defaultEmoji: WalineEmojiPresets[] = [
   '//unpkg.com/@waline/emojis@1.1.0/weibo',
 ];
 
-export const defaultLang = 'zh-CN';
+export const defaultLang = 'en-US';
 
 export const defaultUploadImage = (file: File): Promise<string> =>
   new Promise((resolve, reject) => {

--- a/packages/client/src/config/i18n/index.ts
+++ b/packages/client/src/config/i18n/index.ts
@@ -20,6 +20,7 @@ export const defaultLocales: Locales = {
   'en-US': en,
   'en-us': en,
   jp: jp,
+  ja: jp,
   'jp-jp': jp,
   'jp-JP': jp,
   'pt-br': ptBR,

--- a/packages/client/src/pageview.ts
+++ b/packages/client/src/pageview.ts
@@ -43,7 +43,7 @@ export interface WalinePageviewCountOptions {
    *
    * Language of error message
    *
-   * @default 'zh-CN'
+   * @default navigator.language
    */
   lang?: string;
 }
@@ -62,7 +62,7 @@ export const pageviewCount = ({
   path = window.location.pathname,
   selector = '.waline-pageview-count',
   update = true,
-  lang = 'zh-CN',
+  lang = navigator.language,
 }: WalinePageviewCountOptions): WalineAbort => {
   const controller = new AbortController();
 

--- a/packages/client/src/typings/waline.ts
+++ b/packages/client/src/typings/waline.ts
@@ -117,7 +117,7 @@ export interface WalineProps {
    * - `'ru-ru'`
    * - `'ru-RU'`
    *
-   * @default 'zh-CN'
+   * @default navigator.language
    */
   lang?: string;
 

--- a/packages/client/src/utils/config.ts
+++ b/packages/client/src/utils/config.ts
@@ -66,7 +66,7 @@ export const getConfig = ({
   serverURL,
 
   path = location.pathname,
-  lang = defaultLang,
+  lang = navigator.language,
   locale,
   emoji = defaultEmoji,
   meta = ['nick', 'mail', 'link'],

--- a/packages/client/src/widgets/recentComments.ts
+++ b/packages/client/src/widgets/recentComments.ts
@@ -31,7 +31,7 @@ export interface WalineRecentCommentsOptions {
    *
    * Language of error message
    *
-   * @default 'zh-CN'
+   * @default navigator.language
    */
   lang?: string;
 }
@@ -56,7 +56,7 @@ export const RecentComments = ({
   el,
   serverURL,
   count,
-  lang = 'zh-CN',
+  lang = navigator.language,
 }: WalineRecentCommentsOptions): Promise<WalineRecentCommentsResult> => {
   const userInfo = useUserInfo();
   const root = getRoot(el);

--- a/packages/client/src/widgets/userList.ts
+++ b/packages/client/src/widgets/userList.ts
@@ -30,7 +30,7 @@ export interface WalineUserListOptions {
    *
    * Language of error message
    *
-   * @default 'zh-CN'
+   * @default navigator.language
    */
   lang?: string;
 
@@ -74,7 +74,7 @@ export const UserList = ({
   serverURL,
   count,
   locale,
-  lang = defaultLang,
+  lang = navigator.language,
   mode = 'list',
 }: WalineUserListOptions): Promise<WalineUserListResult> => {
   const root = getRoot(el);

--- a/packages/client/template/icon.html
+++ b/packages/client/template/icon.html
@@ -16,7 +16,6 @@
 
       window.waline = init({
         el: '#waline',
-        lang: 'zh-CN',
         path: '/',
         comment: true,
         pageview: true,

--- a/packages/client/template/init.html
+++ b/packages/client/template/init.html
@@ -15,7 +15,6 @@
 
       window.waline = init({
         el: '#waline',
-        lang: 'zh-CN',
         path: '/',
         comment: true,
         pageview: true,

--- a/packages/client/template/legacy.html
+++ b/packages/client/template/legacy.html
@@ -13,7 +13,6 @@
     <script type="module">
       window.waline = Waline({
         el: '#waline',
-        lang: 'en-US',
         path: '/',
         placeholder: 'valine placeholder',
         langMode: { submit: 'Valine Submit' },


### PR DESCRIPTION
- use `navigator.language` as default lang option value 
- switch to `en-US` as default language