### PR TITLE
fix: some IP attributions cannot be displayed

### DIFF
--- a/packages/server/src/controller/comment.js
+++ b/packages/server/src/controller/comment.js
@@ -53,7 +53,17 @@ async function formatCmt(
 
   // administrator can always show region
   if (isAdmin || !think.config('disableRegion')) {
-    comment.addr = await think.ip2region(ip, { depth: isAdmin ? 3 : 1 });
+    if(isAdmin){
+      comment.addr = await think.ip2region(ip, { depth: 3 });
+    }else{
+      comment.addr = await think.ip2region(ip, { depth: 1 });
+      if(comment.addr == "" || commit.addr == null){
+        comment.addr = await think.ip2region(ip, { depth: 2 });
+        if(commit.addr == "" || commit.addr == null){
+          comment.addr = await think.ip2region(ip, { depth: 3 });
+        }
+      }
+    }
   }
   comment.comment = markdownParser(comment.comment);
   comment.like = Number(comment.like) || 0;
@@ -645,7 +655,8 @@ module.exports = class extends BaseRest {
 
   async putAction() {
     const { userInfo } = this.ctx.state;
-    const isAdmin = userInfo.type === 'administrator';
+    const 
+    min = userInfo.type === 'administrator';
     let data = isAdmin ? this.post() : this.post('comment,like');
     let oldData = await this.modelInstance.select({ objectId: this.id });
 


### PR DESCRIPTION
Some IPs only have data when the depth is 3, so this type of IP will not be able to display the attribution normally
Example: 15.204.56.0/24