### PR TITLE
fix: some IP attributions cannot be displayed

### DIFF
--- a/packages/client/src/components/CommentCard.vue
+++ b/packages/client/src/components/CommentCard.vue
@@ -3,7 +3,7 @@
     <div class="wl-user" aria-hidden="true">
       <img v-if="comment.avatar" :src="comment.avatar" />
 
-      <VerifiedIcon v-if="comment.type" />
+      <VerifiedIcon v-if="comment.type === 'administrator'" />
     </div>
 
     <div class="wl-card">

--- a/packages/server/src/controller/comment.js
+++ b/packages/server/src/controller/comment.js
@@ -53,7 +53,17 @@ async function formatCmt(
 
   // administrator can always show region
   if (isAdmin || !think.config('disableRegion')) {
-    comment.addr = await think.ip2region(ip, { depth: isAdmin ? 3 : 1 });
+    if(isAdmin){
+      comment.addr = await think.ip2region(ip, { depth: 3 });
+    }else{
+      comment.addr = await think.ip2region(ip, { depth: 1 });
+      if(comment.addr == "" || commit.addr == null){
+        comment.addr = await think.ip2region(ip, { depth: 2 });
+        if(commit.addr == "" || commit.addr == null){
+          comment.addr = await think.ip2region(ip, { depth: 3 });
+        }
+      }
+    }
   }
   comment.comment = markdownParser(comment.comment);
   comment.like = Number(comment.like) || 0;

--- a/packages/server/src/controller/comment.js
+++ b/packages/server/src/controller/comment.js
@@ -57,9 +57,9 @@ async function formatCmt(
       comment.addr = await think.ip2region(ip, { depth: 3 });
     }else{
       comment.addr = await think.ip2region(ip, { depth: 1 });
-      if(comment.addr == "" || commit.addr == null){
+      if(comment.addr == "" || comment.addr == null){
         comment.addr = await think.ip2region(ip, { depth: 2 });
-        if(commit.addr == "" || commit.addr == null){
+        if(comment.addr == "" || comment.addr == null){
           comment.addr = await think.ip2region(ip, { depth: 3 });
         }
       }


### PR DESCRIPTION
Some IPs only have data when the depth is 3, so this type of IP will not be able to display the attribution normally
Example: 15.204.56.0/24