### PR TITLE
Export utils for other libraries

### DIFF
--- a/packages/client/rollup.config.mjs
+++ b/packages/client/rollup.config.mjs
@@ -195,6 +195,35 @@ export default [
     plugins: [dts({ compilerOptions: { preserveSymlinks: false } })],
   },
 
+  // utils
+  {
+    input: './src/entries/utils.ts',
+    output: [
+      {
+        file: './dist/utils.cjs',
+        format: 'cjs',
+        sourcemap: true,
+      },
+      {
+        file: './dist/utils.mjs',
+        format: 'esm',
+        sourcemap: true,
+      },
+    ],
+    ...commonOptions,
+  },
+
+  // utils declaration files
+  {
+    input: './src/entries/utils.ts',
+    output: [
+      { file: './dist/utils.d.ts', format: 'esm' },
+      { file: './dist/utils.d.cts', format: 'esm' },
+      { file: './dist/utils.d.mts', format: 'esm' },
+    ],
+    plugins: [dts({ compilerOptions: { preserveSymlinks: false } })],
+  },
+
   // comment
   {
     input: './src/entries/comment.ts',

--- a/packages/client/src/entries/utils.ts
+++ b/packages/client/src/entries/utils.ts
@@ -1,0 +1,1 @@
+export * from '../utils';


### PR DESCRIPTION
I'm writing [sodesu](https://github.com/lixiang810/sodesu), which is a waline compatible comment system. It uses `api` and `utils` from waline. `api` is ok, as it has been exported. But `utils` is not, I have to import it like `import { getRoot } from '@waline/client/src/utils/getRoot';`, which causes error when I'm trying to bundle `sodesu` using `rollup`.

```bash
[!] Error: Could not load C:\Other\project\sodesu\node_modules\.pnpm\@waline+client@2.14.7\node_modules\@waline\client\src\utils\getRoot (imported by srcline+client@2.14.7\node_modules\@waline\client\src\utils\getRoot'
```

There must be a way to solve the problem, but for me, it's much easier to open a pull request to waline.