### PR TITLE
fix(client): fix style issues

### DIFF
--- a/packages/client/src/styles/card.scss
+++ b/packages/client/src/styles/card.scss
@@ -53,28 +53,30 @@
     border-bottom: none;
   }
 
-  .wl-head {
-    // bfc to fix https://github.com/walinejs/waline/issues/1415
-    overflow: hidden;
-    line-height: 1.5;
-  }
-
   .wl-nick {
-    position: relative;
-
-    display: inline-block;
-
-    margin-inline-end: 0.5em;
-
-    font-weight: bold;
-    font-size: 0.875em;
-    line-height: 1;
-    text-decoration: none;
-
     svg {
       position: relative;
       bottom: -0.125em;
       line-height: 1;
+    }
+  }
+
+  .wl-head {
+    // bfc to fix https://github.com/walinejs/waline/issues/1415
+    overflow: hidden;
+    line-height: 1.5;
+
+    .wl-nick {
+      position: relative;
+  
+      display: inline-block;
+  
+      margin-inline-end: 0.5em;
+  
+      font-weight: bold;
+      font-size: 0.875em;
+      line-height: 1;
+      text-decoration: none;
     }
   }
 

--- a/packages/client/src/styles/card.scss
+++ b/packages/client/src/styles/card.scss
@@ -49,7 +49,7 @@
     margin-inline-start: 1em;
   }
 
-  .wl-card-item:last-child & {
+  .wl-card-item:last-child > & {
     border-bottom: none;
   }
 


### PR DESCRIPTION
最近将 valine 升级到 waline，在适配样式的时候，发现了 2 个小问题：
- 第一个问题：在回复评论的时候，昵称输入框会存在 margin-inline-end: 0.5em; 的属性，这个是由于与评论列表中的昵称样式匹配到了的原因，PS：昵称内容加粗也是，如果你们故意的当我没说。
- 第二个问题：在页面显示的最后一条评论有回复内容的时候，回复的评论内容下面的 border-bottom 会消失，无论它是不是最后一条。
![1](https://user-images.githubusercontent.com/35484849/224342623-d86d56c1-b59f-42b1-adea-ff4274464c02.png)图片来自于 Waline 文档
