### PR TITLE
docs: update docs

### DIFF
--- a/docs/src/reference/server/env.md
+++ b/docs/src/reference/server/env.md
@@ -73,7 +73,7 @@ Vercel 需要在 <kbd>Settings</kbd> - <kbd>Environment Variables</kbd> 中进�
 
 Recaptcha Key 和 Secret 可在 <https://www.google.com/recaptcha> 申请。
 
-配置时安全域名需要同时添加网站地址和 Waline 服务端地址。
+配置时安全域名需要同时添加网站地址和 Waline 服务端地址（不包含传输协议，即 `http://` 或 `https://`）。
 
 :::
 


### PR DESCRIPTION
在服务端配置环境变量的时候，Vercel 可以正常启动 Waline 服务端，但是在测试评论的时候有问题。
问题详情：页面获取评论的时候出错，评论的时候页面提示 `path missing )` ，在 LeanCloud 中查看发现评论数据已经存储。
问题原因：经过排查 Waline 服务端的环境变量，发现由于配置安全域名 `SECURE_DOMAINS` 时，添加了传输协议的原因。
因此我修改了文档，补充了这一点。