### PR TITLE
为昵称处的网址加上nofollow

### DIFF
--- a/packages/client/src/components/CommentCard.vue
+++ b/packages/client/src/components/CommentCard.vue
@@ -13,7 +13,7 @@
           class="wl-nick"
           :href="link"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="nofollow noopener noreferrer"
           >{{ comment.nick }}</a
         >
 


### PR DESCRIPTION
见 [discussions/1863](https://github.com/orgs/walinejs/discussions/1863)，目前只有评论正文里的网址才有 nofollow，而且该提问者指的也是昵称处的网址，故完善。