### PR TITLE
fix: fix #1961

### DIFF
--- a/packages/client/src/components/CommentBox.vue
+++ b/packages/client/src/components/CommentBox.vue
@@ -526,8 +526,7 @@ const submitComment = async (): Promise<void> => {
     // check mail
     if (
       (requiredMeta.indexOf('mail') > -1 && !comment.mail) ||
-      (comment.mail &&
-        !/^\w(?:[\w._-]*\w)?@(?:\w(?:[\w-]*\w)?\.)*\w+$/.exec(comment.mail))
+      (comment.mail && !inputRefs.value.mail.checkValidity())
     ) {
       inputRefs.value.mail?.focus();
 


### PR DESCRIPTION
 Use system method instead of regex validation https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/checkValidity

close #1961 when pr merged.