### PR TITLE
chore(client): add component declaration rollup config

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,7 +31,8 @@
       "default": "./dist/api.mjs"
     },
     "./component": {
-      "default": "./dist/component.mjs"
+      "default": "./dist/component.mjs",
+      "types": "./dist/component.d.ts"
     },
     "./full": {
       "types": "./dist/waline.d.ts",
@@ -59,7 +60,8 @@
       "default": "./dist/api.mjs"
     },
     "./dist/component": {
-      "default": "./dist/component.mjs"
+      "default": "./dist/component.mjs",
+      "types": "./dist/component.d.ts"
     },
     "./dist/comment": {
       "types": "./dist/comment.d.ts",

--- a/packages/client/rollup.config.mjs
+++ b/packages/client/rollup.config.mjs
@@ -164,7 +164,15 @@ export default [
   },
 
   // components declaration files
-  // TODO: Generate declaration files
+  {
+    input: './src/entries/components.ts',
+    output: [
+      { file: './dist/component.d.cts', format: 'esm' },
+      { file: './dist/component.d.mts', format: 'esm' },
+      { file: './dist/component.d.ts', format: 'esm'}
+    ],
+    plugins: [vue(), ts(), dts({ compilerOptions: { preserveSymlinks: false } })],
+  },
 
   // api
   {


### PR DESCRIPTION
# The problem

When I use `@waline/client` in my project, it comes the "Could not find a declaration file or module '@waline/client/component'." error.

![image](https://github.com/walinejs/waline/assets/57290456/5c111835-9bbe-4b28-8844-40d1430c6ead)

# Why

Looking into the `client` package of `waline`, I found there was a `TODO` mark and was lack of dts configuration for `component.ts`.

# How I resolved

Running the build command, I found it saying rollup plugin is required.

After putting `@vitejs/plugin-vue` and `rollup-plugin-ts` before `rollup-plugin-dts`, it works!! 🎉

# Tests

I added the `component.d.ts` file in the `node_modules` of my project, modified the `package.json` and the error disappeared.

![image](https://github.com/walinejs/waline/assets/57290456/1b77954a-b30c-4f98-afa4-05a6abf08597)

