### PR TITLE
修复：将 Tex/TEX 转为 TeX || Fix: Convert Tex/TEX to TeX

### DIFF
--- a/docs/src/cookbook/README.md
+++ b/docs/src/cookbook/README.md
@@ -23,7 +23,7 @@ icon: cookbook
 - [添加代码高亮器](./customize/highlighter.md)
 - [为评论区添加图片预览](./customize/image-preview.md)
 - [自定义表情包搜索](./customize/search.md)
-- [添加 TEX 渲染器](./customize/tex-renderer.md)
+- [添加 TeX 渲染器](./customize/tex-renderer.md)
 - [上传图片](./customize/upload-image.md)
 - [自定义数据库服务](./customize/database.md)
 - [自定义用户系统](./customize/userdb.md)

--- a/docs/src/cookbook/customize/tex-renderer.md
+++ b/docs/src/cookbook/customize/tex-renderer.md
@@ -1,9 +1,9 @@
 ---
-title: 添加 TEX 渲染器
+title: 添加 TeX 渲染器
 icon: tex
 ---
 
-本教程将指导你设置自己的 Tex 渲染器。
+本教程将指导你设置自己的 TeX 渲染器。
 
 <!-- more -->
 

--- a/docs/src/en/cookbook/README.md
+++ b/docs/src/en/cookbook/README.md
@@ -23,7 +23,7 @@ This cookbook will introduce Waline in more depth.
 - [Add code highlighter](./customize/highlighter.md)
 - [Add image preview for comment area](./customize/image-preview.md)
 - [Customize emoticon search](./customize/search.md)
-- [Add TEX renderer](./customize/tex-renderer.md)
+- [Add TeX renderer](./customize/tex-renderer.md)
 - [Upload Image](./customize/upload-image.md)
 - [Custom Database Service](./customize/database.md)
 - [Custom User System](./customize/userdb.md)

--- a/docs/src/en/cookbook/customize/tex-renderer.md
+++ b/docs/src/en/cookbook/customize/tex-renderer.md
@@ -1,5 +1,5 @@
 ---
-title: Customize TEX renderer
+title: Customize TeX renderer
 ---
 
 This cookbook guides you on how to add your own $\TeX$ renderer.

--- a/docs/src/en/reference/client/props.md
+++ b/docs/src/en/reference/client/props.md
@@ -208,10 +208,10 @@ You can pass in a code highlighter of your own, or set to `false` to disable cod
 
 ## texRenderer
 
-- Type: `WalineTexRenderer | false`
+- Type: `WalineTeXRenderer | false`
 
   ```ts
-  type WalineTexRenderer = (blockMode: boolean, tex: string) => string;
+  type WalineTeXRenderer = (blockMode: boolean, tex: string) => string;
   ```
 
 - Required: No

--- a/docs/src/guide/features/syntax.md
+++ b/docs/src/guide/features/syntax.md
@@ -39,7 +39,7 @@ Github Flavored Markdown, 即 Github 风格语法
 
 - $\TeX$ 语法，也就是数学公式 (如: `$a = 1$`) 默认无法渲染。
 
-  在官方客户端下，你可以通过设置 `texRenderer` 选项来设置预览时的 $\TeX$ 渲染,，参见 [Cookbook → 使用自定义 TEX 渲染器](../../cookbook/customize/tex-renderer.md)。
+  在官方客户端下，你可以通过设置 `texRenderer` 选项来设置预览时的 $\TeX$ 渲染,，参见 [Cookbook → 使用自定义 TeX 渲染器](../../cookbook/customize/tex-renderer.md)。
 
 - 在默认的高亮器下，代码块将通过特定分隔符使用随机颜色进行高亮。
 

--- a/docs/src/reference/client/props.md
+++ b/docs/src/reference/client/props.md
@@ -206,10 +206,10 @@ Waline 多语言配置。
 
 ## texRenderer
 
-- 类型: `WalineTexRenderer | false`
+- 类型: `WalineTeXRenderer | false`
 
   ```ts
-  type WalineTexRenderer = (blockMode: boolean, tex: string) => string;
+  type WalineTeXRenderer = (blockMode: boolean, tex: string) => string;
   ```
 
 - 必填: 否

--- a/docs/src/reference/server/env.md
+++ b/docs/src/reference/server/env.md
@@ -90,7 +90,7 @@ Recaptcha Key 和 Secret 可在 <https://www.google.com/recaptcha> 申请。
 | `MARKDOWN_EMOJI`     | `true`    | 是否启用 Emoji 缩写支持                           |
 | `MARKDOWN_SUB`       | `true`    | 是否启用下角标支持                                |
 | `MARKDOWN_SUP`       | `true`    | 是否启用上角标支持                                |
-| `MARKDOWN_TEX`       | `mathjax` | 解析 Tex 的服务，支持 `mathjax`、`katex`、`false` |
+| `MARKDOWN_TEX`       | `mathjax` | 解析 TeX 的服务，支持 `mathjax`、`katex`、`false` |
 | `MARKDOWN_MATHJAX`   | `{}`      | MathJax 选项                                      |
 | `MARKDOWN_KATEX`     | `{}`      | Katex 选项                                        |
 

--- a/packages/client/__tests__/markedMathExtension.spec.ts
+++ b/packages/client/__tests__/markedMathExtension.spec.ts
@@ -1,10 +1,10 @@
 import { marked } from 'marked';
 import { describe, expect, it } from 'vitest';
 
-import { defaultTexRenderer } from '../src/config/index.js';
-import { markedTexExtensions } from '../src/utils/markedMathExtension.js';
+import { defaultTeXRenderer } from '../src/config/index.js';
+import { markedTeXExtensions } from '../src/utils/markedMathExtension.js';
 
-const extensions = markedTexExtensions(defaultTexRenderer);
+const extensions = markedTeXExtensions(defaultTeXRenderer);
 
 marked.setOptions({
   highlight: undefined,
@@ -17,55 +17,55 @@ marked.use({ extensions });
 describe('Should parse inline tex', () => {
   it('Single word', () => {
     expect(marked.parse('$a$')).toEqual(
-      '<p><span class="wl-tex">Tex is not available in preview</span></p>\n'
+      '<p><span class="wl-tex">TeX is not available in preview</span></p>\n'
     );
 
     expect(marked.parse('$a$ is at beginning')).toEqual(
-      '<p><span class="wl-tex">Tex is not available in preview</span> is at beginning</p>\n'
+      '<p><span class="wl-tex">TeX is not available in preview</span> is at beginning</p>\n'
     );
 
     expect(marked.parse('Here ends a single tex $a$')).toEqual(
-      '<p>Here ends a single tex <span class="wl-tex">Tex is not available in preview</span></p>\n'
+      '<p>Here ends a single tex <span class="wl-tex">TeX is not available in preview</span></p>\n'
     );
 
     expect(marked.parse('Here is a single tex $a$ in the sentence')).toEqual(
-      '<p>Here is a single tex <span class="wl-tex">Tex is not available in preview</span> in the sentence</p>\n'
+      '<p>Here is a single tex <span class="wl-tex">TeX is not available in preview</span> in the sentence</p>\n'
     );
 
     expect(marked.parse('$-$')).toEqual(
-      '<p><span class="wl-tex">Tex is not available in preview</span></p>\n'
+      '<p><span class="wl-tex">TeX is not available in preview</span></p>\n'
     );
   });
 
   it('Mutiple words', () => {
     expect(marked.parse('$a = 1$')).toEqual(
-      '<p><span class="wl-tex">Tex is not available in preview</span></p>\n'
+      '<p><span class="wl-tex">TeX is not available in preview</span></p>\n'
     );
 
     expect(marked.parse('$a = 1$ is at beginning')).toEqual(
-      '<p><span class="wl-tex">Tex is not available in preview</span> is at beginning</p>\n'
+      '<p><span class="wl-tex">TeX is not available in preview</span> is at beginning</p>\n'
     );
 
     expect(marked.parse('Here ends a single tex $a = 1$')).toEqual(
-      '<p>Here ends a single tex <span class="wl-tex">Tex is not available in preview</span></p>\n'
+      '<p>Here ends a single tex <span class="wl-tex">TeX is not available in preview</span></p>\n'
     );
 
     expect(
       marked.parse('Here is a single tex $a = 1$ in the sentence')
     ).toEqual(
-      '<p>Here is a single tex <span class="wl-tex">Tex is not available in preview</span> in the sentence</p>\n'
+      '<p>Here is a single tex <span class="wl-tex">TeX is not available in preview</span> in the sentence</p>\n'
     );
 
     expect(marked.parse('$-\\sqrt{x}$')).toEqual(
-      '<p><span class="wl-tex">Tex is not available in preview</span></p>\n'
+      '<p><span class="wl-tex">TeX is not available in preview</span></p>\n'
     );
 
     expect(marked.parse('$-\\sqrt{x}$ is at beginning')).toEqual(
-      '<p><span class="wl-tex">Tex is not available in preview</span> is at beginning</p>\n'
+      '<p><span class="wl-tex">TeX is not available in preview</span> is at beginning</p>\n'
     );
 
     expect(marked.parse('Here ends a single tex $-\\sqrt{x}$')).toEqual(
-      '<p>Here ends a single tex <span class="wl-tex">Tex is not available in preview</span></p>\n'
+      '<p>Here ends a single tex <span class="wl-tex">TeX is not available in preview</span></p>\n'
     );
   });
 
@@ -77,13 +77,13 @@ describe('Should parse inline tex', () => {
 describe('Should parse block tex', () => {
   it('Single line', () => {
     expect(marked.parse('$$a$$')).toEqual(
-      '<p class="wl-tex">Tex is not available in preview</p>'
+      '<p class="wl-tex">TeX is not available in preview</p>'
     );
   });
 
   it('Mutiple lines', () => {
     expect(marked.parse('$$\na\n$$')).toEqual(
-      '<p class="wl-tex">Tex is not available in preview</p>'
+      '<p class="wl-tex">TeX is not available in preview</p>'
     );
   });
 

--- a/packages/client/src/compact/v1.ts
+++ b/packages/client/src/compact/v1.ts
@@ -1,7 +1,7 @@
 import {
   type WalineHighlighter,
   type WalineImageUploader,
-  type WalineTexRenderer,
+  type WalineTeXRenderer,
 } from '../typings/index.js';
 
 export interface DeprecatedWalineOptions {
@@ -80,11 +80,11 @@ export interface DeprecatedWalineOptions {
   /**
    * @deprecated Use `texRenderer` instead, dropped in V2
    *
-   * 自定义 Tex 处理方法，用于预览。
+   * 自定义 TeX 处理方法，用于预览。
    *
    * Custom math formula parse callback for preview.
    */
-  previewMath?: WalineTexRenderer | false;
+  previewMath?: WalineTeXRenderer | false;
 
   /**
    * @deprecated use `copyright` instead, dropped in V2

--- a/packages/client/src/config/default.ts
+++ b/packages/client/src/config/default.ts
@@ -39,10 +39,10 @@ export const defaultUploadImage = (file: File): Promise<string> =>
     reader.onerror = reject;
   });
 
-export const defaultTexRenderer = (blockMode: boolean): string =>
+export const defaultTeXRenderer = (blockMode: boolean): string =>
   blockMode === true
-    ? '<p class="wl-tex">Tex is not available in preview</p>'
-    : '<span class="wl-tex">Tex is not available in preview</span>';
+    ? '<p class="wl-tex">TeX is not available in preview</p>'
+    : '<span class="wl-tex">TeX is not available in preview</span>';
 
 export const getDefaultSearchOptions = (lang: string): WalineSearchOptions => {
   interface GifResult {

--- a/packages/client/src/typings/base.ts
+++ b/packages/client/src/typings/base.ts
@@ -120,4 +120,4 @@ export type WalineImageUploader = (image: File) => Promise<string>;
 
 export type WalineHighlighter = (code: string, lang: string) => string;
 
-export type WalineTexRenderer = (blockMode: boolean, tex: string) => string;
+export type WalineTeXRenderer = (blockMode: boolean, tex: string) => string;

--- a/packages/client/src/typings/waline.ts
+++ b/packages/client/src/typings/waline.ts
@@ -6,7 +6,7 @@ import {
   type WalineImageUploader,
   type WalineLoginStatus,
   type WalineMeta,
-  type WalineTexRenderer,
+  type WalineTeXRenderer,
   type WalineSearchOptions,
 } from './base.js';
 import { type WalineLocale } from './locale.js';
@@ -201,7 +201,7 @@ export interface WalineProps {
    *
    * @default true
    */
-  texRenderer?: WalineTexRenderer | boolean;
+  texRenderer?: WalineTeXRenderer | boolean;
 
   /**
    *

--- a/packages/client/src/utils/config.ts
+++ b/packages/client/src/utils/config.ts
@@ -6,7 +6,7 @@ import {
   DEFAULT_REACTION,
   defaultUploadImage,
   defaultHighlighter,
-  defaultTexRenderer,
+  defaultTeXRenderer,
   getDefaultSearchOptions,
   getMeta,
 } from '../config/index.js';
@@ -97,7 +97,7 @@ export const getConfig = ({
   requiredMeta: getMeta(requiredMeta),
   imageUploader: fallback(imageUploader, defaultUploadImage),
   highlighter: fallback(highlighter, defaultHighlighter),
-  texRenderer: fallback(texRenderer, defaultTexRenderer),
+  texRenderer: fallback(texRenderer, defaultTeXRenderer),
   lang: Object.keys(DEFAULT_LOCALES).includes(lang) ? lang : 'en-US',
   dark,
   emoji: typeof emoji === 'boolean' ? (emoji ? DEFAULT_EMOJI : []) : emoji,

--- a/packages/client/src/utils/markdown.ts
+++ b/packages/client/src/utils/markdown.ts
@@ -1,10 +1,10 @@
 import { marked } from 'marked';
 
-import { markedTexExtensions } from './markedMathExtension.js';
+import { markedTeXExtensions } from './markedMathExtension.js';
 import {
   type WalineEmojiMaps,
   type WalineHighlighter,
-  type WalineTexRenderer,
+  type WalineTeXRenderer,
 } from '../typings/index.js';
 
 export const parseEmoji = (text = '', emojiMap: WalineEmojiMaps = {}): string =>
@@ -17,7 +17,7 @@ export const parseEmoji = (text = '', emojiMap: WalineEmojiMaps = {}): string =>
 export interface ParseMarkdownOptions {
   emojiMap: WalineEmojiMaps;
   highlighter: WalineHighlighter | false;
-  texRenderer: WalineTexRenderer | false;
+  texRenderer: WalineTeXRenderer | false;
 }
 
 export const parseMarkdown = (
@@ -32,7 +32,7 @@ export const parseMarkdown = (
   });
 
   if (texRenderer) {
-    const extensions = markedTexExtensions(texRenderer);
+    const extensions = markedTeXExtensions(texRenderer);
 
     marked.use({ extensions });
   }

--- a/packages/client/src/utils/markedMathExtension.ts
+++ b/packages/client/src/utils/markedMathExtension.ts
@@ -1,13 +1,13 @@
 import { type marked } from 'marked';
 
-import { type WalineTexRenderer } from '../typings/index.js';
+import { type WalineTeXRenderer } from '../typings/index.js';
 
 const inlineMathStart = /\$.*?\$/;
 const inlineMathReg = /^\$(.*?)\$/;
 const blockMathReg = /^(?:\s{0,3})\$\$((?:[^\n]|\n[^\n])+?)\n{0,1}\$\$/;
 
-export const markedTexExtensions = (
-  texRenderer: WalineTexRenderer
+export const markedTeXExtensions = (
+  texRenderer: WalineTeXRenderer
 ): marked.TokenizerExtension[] => {
   const blockMathExtension: marked.TokenizerExtension = {
     name: 'blockMath',

--- a/packages/server/src/service/markdown/katex.js
+++ b/packages/server/src/service/markdown/katex.js
@@ -1,6 +1,6 @@
 const katex = require('katex');
 
-const { inlineTex, blockTex } = require('./mathCommon');
+const { inlineTeX, blockTeX } = require('./mathCommon');
 const { escapeHtml } = require('./utils');
 
 // set KaTeX as the renderer for markdown-it-simplemath
@@ -31,17 +31,17 @@ const katexBlock = (tex, options) => {
 };
 
 const katexPlugin = (md, options = { throwOnError: false }) => {
-  md.inline.ruler.after('escape', 'inlineTex', inlineTex);
+  md.inline.ruler.after('escape', 'inlineTeX', inlineTeX);
 
   // It’s a workaround here because types issue
-  md.block.ruler.after('blockquote', 'blockTex', blockTex, {
+  md.block.ruler.after('blockquote', 'blockTeX', blockTeX, {
     alt: ['paragraph', 'reference', 'blockquote', 'list'],
   });
 
-  md.renderer.rules.inlineTex = (tokens, idx) =>
+  md.renderer.rules.inlineTeX = (tokens, idx) =>
     katexInline(tokens[idx].content, options);
 
-  md.renderer.rules.blockTex = (tokens, idx) =>
+  md.renderer.rules.blockTeX = (tokens, idx) =>
     `${katexBlock(tokens[idx].content, options)}\n`;
 };
 

--- a/packages/server/src/service/markdown/mathCommon.js
+++ b/packages/server/src/service/markdown/mathCommon.js
@@ -20,7 +20,7 @@ const isValidDelim = (state, pos) => {
   };
 };
 
-const inlineTex = (state, silent) => {
+const inlineTeX = (state, silent) => {
   let match;
   let pos;
   let res;
@@ -83,7 +83,7 @@ const inlineTex = (state, silent) => {
   }
 
   if (!silent) {
-    token = state.push('inlineTex', 'math', 0);
+    token = state.push('inlineTeX', 'math', 0);
     token.markup = '$';
     token.content = state.src.slice(start, match);
   }
@@ -93,7 +93,7 @@ const inlineTex = (state, silent) => {
   return true;
 };
 
-const blockTex = (state, start, end, silent) => {
+const blockTeX = (state, start, end, silent) => {
   let firstLine;
   let lastLine;
   let next;
@@ -133,7 +133,7 @@ const blockTex = (state, start, end, silent) => {
 
   state.line = next + 1;
 
-  const token = state.push('blockTex', 'math', 0);
+  const token = state.push('blockTeX', 'math', 0);
 
   token.block = true;
   token.content =
@@ -151,6 +151,6 @@ const blockTex = (state, start, end, silent) => {
 };
 
 module.exports = {
-  inlineTex,
-  blockTex,
+  inlineTeX,
+  blockTeX,
 };

--- a/packages/server/src/service/markdown/mathjax.js
+++ b/packages/server/src/service/markdown/mathjax.js
@@ -5,7 +5,7 @@ const { TeX } = require('mathjax-full/js/input/tex.js');
 const { mathjax } = require('mathjax-full/js/mathjax');
 const { SVG } = require('mathjax-full/js/output/svg.js');
 
-const { inlineTex, blockTex } = require('./mathCommon');
+const { inlineTeX, blockTeX } = require('./mathCommon');
 const { escapeHtml } = require('./utils');
 
 // set MathJax as the renderer
@@ -59,17 +59,17 @@ class MathToSvg {
 const mathjaxPlugin = (md) => {
   const mathToSvg = new MathToSvg();
 
-  md.inline.ruler.after('escape', 'inlineTex', inlineTex);
+  md.inline.ruler.after('escape', 'inlineTeX', inlineTeX);
 
   // It’s a workaround here because types issue
-  md.block.ruler.after('blockquote', 'blockTex', blockTex, {
+  md.block.ruler.after('blockquote', 'blockTeX', blockTeX, {
     alt: ['paragraph', 'reference', 'blockquote', 'list'],
   });
 
-  md.renderer.rules.inlineTex = (tokens, idx) =>
+  md.renderer.rules.inlineTeX = (tokens, idx) =>
     mathToSvg.inline(tokens[idx].content);
 
-  md.renderer.rules.blockTex = (tokens, idx) =>
+  md.renderer.rules.blockTeX = (tokens, idx) =>
     `${mathToSvg.block(tokens[idx].content)}\n`;
 };
 


### PR DESCRIPTION
> TeX这个词的标准发音为/tɛx/，其中/x/相当于中文里“赫”字的[声母](https://zh.wikipedia.org/wiki/%E5%A3%B0%E6%AF%8D)，或者[苏格兰语](https://zh.wikipedia.org/wiki/%E4%BD%8E%E5%9C%B0%E8%98%87%E6%A0%BC%E8%98%AD%E8%AA%9E)“loch”一词中“ch”的发音（X其实是[希腊字母](https://zh.wikipedia.org/wiki/%E5%B8%8C%E8%85%8A%E5%AD%97%E6%AF%8D) χ）。发音接近“泰赫”。在[英语](https://zh.wikipedia.org/wiki/%E8%8B%B1%E8%AF%AD)和[法语](https://zh.wikipedia.org/wiki/%E6%B3%95%E8%AF%AD)中实际通常读作/tɛk/，发音接近“泰克”。TeX这个词来自[希腊文](https://zh.wikipedia.org/wiki/%E5%B8%8C%E8%85%8A%E6%96%87)中的 τέχνη （TEXNH），希腊文意为“艺术”和“制造”，也是英语中 technical（技术）的词源。书写时，三个字母都是大写，字母E应当低于其他两个字母。**而不支持下标的系统则只能这样书写：“TeX”。**（[维基百科](https://zh.wikipedia.org/wiki/TeX#%E5%8F%91%E9%9F%B3%E5%92%8C%E6%8B%BC%E5%86%99)）

根据上述规范，我将项目中的 Tex/TEX 替换为了 TeX。tex 保留的原因是为符合文件名等命名规范而可以做出妥协，但 Tex/TEX 实在不具有美感，因此进行了替换。

我比较担心的是这个 PR 也修改了部分变量、函数等名称，可能会造成一些破坏。如果有影响的话，我可以后续撤销这部分的更改。

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
> The standard pronunciation of the word TeX is /tɛx/, where /x/ is equivalent to the [consonant] of the word "He" in Chinese (https://zh.wikipedia.org/wiki/%E5%A3%B0%E6% AF%8D), or [Scottish](https://zh.wikipedia.org/wiki/%E4%BD%8E%E5%9C%B0%E8%98%87%E6%A0%BC%E8% 98%AD%E8%AA%9E) The "ch" sound in the word "loch" (X is actually the [Greek letter](https://zh.wikipedia.org/wiki/%E5%B8%8C%E8 %85%8A%E5%AD%97%E6%AF%8D) χ). Pronunciation is close to "Taihe". In [English](https://zh.wikipedia.org/wiki/%E8%8B%B1%E8%AF%AD) and [French](https://zh.wikipedia.org/wiki/%E6% B3%95%E8%AF%AD) is actually usually pronounced /tɛk/, pronounced close to "Tek". The word TeX comes from [Greek](https://zh.wikipedia.org/wiki/%E5%B8%8C%E8%85%8A%E6%96%87) in τέχνη (TEXNH), Greek meaning For "art" and "manufacturing", and also the etymology of technical in English. When writing, all three letters are capitalized, and the letter E should be lower than the other two letters. ** Systems that do not support subscripts can only write: "TeX". **([Wikipedia](https://zh.wikipedia.org/wiki/TeX#%E5%8F%91%E9%9F%B3%E5%92%8C%E6%8B%BC%E5%86 %99))

According to the above specification, I replaced Tex/TEX in the project with TeX. The reason why tex is kept is that compromises can be made to comply with naming conventions such as file names, but Tex/TEX is really not aesthetically pleasing, so it has been replaced.

What I am more worried about is that this PR also modifies the names of some variables, functions, etc., which may cause some damage. I can later undo this part of the change if it has an impact.
