### PR TITLE
使用card消息类型美化飞书通知消息 || Use the card message type to beautify the Feishu notification message

### DIFF
--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -3,7 +3,6 @@ const crypto = require('crypto');
 const FormData = require('form-data');
 const fetch = require('node-fetch');
 const nodemailer = require('nodemailer');
-const nunjucks = require('nunjucks');
 
 module.exports = class extends think.Service {
   constructor(ctx) {
@@ -395,44 +394,121 @@ module.exports = class extends think.Service {
       return false;
     }
 
-    self.comment = self.comment.replace(/(<([^>]+)>)/gi, '');
-
-    const data = {
-      self,
-      parent,
-      site: {
-        name: SITE_NAME,
-        url: SITE_URL,
-        postUrl: SITE_URL + self.url + '#' + self.objectId,
-      },
-    };
-
-    content = nunjucks.renderString(
-      think.config('LarkTemplate') ||
-        `【网站名称】：{{site.name|safe}} \n【评论者昵称】：{{self.nick}}\n【评论者邮箱】：{{self.mail}}\n【内容】：{{self.comment}}【地址】：{{site.postUrl}}`,
-      data,
-    );
-
-    const post = {
-      en_us: {
-        title: this.ctx.locale(title, data),
-        content: [
-          [
-            {
-              tag: 'text',
-              text: content,
-            },
-          ],
-        ],
-      },
-    };
+    // 文章地址
+    const postUrl = SITE_URL + self.url;
+    // 评论地址
+    const commentUrl = SITE_URL + self.url + '#' + self.objectId;
 
     let signData = {};
     const msg = {
-      msg_type: 'post',
-      content: {
-        post,
-      },
+      "msg_type": "interactive",
+      "card": {
+        "header": {
+          "template": "blue",
+          "title": {
+            "tag": "plain_text",
+            "content": `🌥️🌥️🌥️ ${SITE_NAME} 有新评论啦`
+          }
+        },
+        "elements": [
+          {
+            "tag": "markdown",
+            "content": `**文章地址:** [${postUrl}](${postUrl})`
+          },
+          {
+            "tag": "hr"
+          },
+          {
+            "tag": "column_set",
+            "flex_mode": "none",
+            "background_style": "default",
+            "columns": [
+              {
+                "tag": "column",
+                "width": "weighted",
+                "weight": 1,
+                "vertical_align": "top",
+                "elements": [
+                  {
+                    "tag": "markdown",
+                    "content": `**🌥️ 站点名称\n<font color='red'> ${SITE_NAME}</font>** `,
+                    "text_align": "center"
+                  }
+                ]
+              },
+              {
+                "tag": "column",
+                "width": "weighted",
+                "weight": 1,
+                "vertical_align": "top",
+                "elements": [
+                  {
+                    "tag": "markdown",
+                    "content": `**👤 昵称** \n[${self.nick}](${self.link})`,
+                    "text_align": "center"
+                  }
+                ]
+              },
+              {
+                "tag": "column",
+                "width": "weighted",
+                "weight": 1,
+                "vertical_align": "top",
+                "elements": [
+                  {
+                    "tag": "markdown",
+                    "content": `**📪 邮箱\n<font color='green'> ${self.mail}</font>**`,
+                    "text_align": "center"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "tag": "column_set",
+            "flex_mode": "none",
+            "background_style": "grey",
+            "columns": [
+              {
+                "tag": "column",
+                "width": "weighted",
+                "weight": 1,
+                "vertical_align": "top",
+                "elements": [
+                  {
+                    "tag": "markdown",
+                    "content": "**📝 评论内容 📝**",
+                    "text_align": "center"
+                  },
+                  {
+                    "tag": "markdown",
+                    "content": self.comment
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "tag": "action",
+            "actions": [
+              {
+                "tag": "button",
+                "text": {
+                  "tag": "plain_text",
+                  "content": "查看完整內容"
+                },
+                "type": "primary",
+                "multi_url": {
+                  "url": commentUrl,
+                  "pc_url": "",
+                  "android_url": "",
+                  "ios_url": ""
+                }
+              }
+            ]
+          }
+        ]
+      }
     };
 
     const sign = (timestamp, secret) => {


### PR DESCRIPTION
因为看不习惯飞书通知的消息格式，强迫证犯了，使用飞书card消息类型美化了一下格式，对比如下：

原消息格式：
![WX20230906-180742@2x](https://github.com/walinejs/waline/assets/1457297/c3043c37-bf92-4d01-b499-f68f0b5fd4a9)

美化后消息格式：
![WX20230906-180809@2x](https://github.com/walinejs/waline/assets/1457297/7b7b9ccc-5799-48ff-bc04-2616b6850532)

自我感觉好看多了~_~

PS：目前缺陷是不能使用`LARK_TEMPLATE`消息模板了
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
Because I am not used to the message format of the Feishu notification, I forced the card to commit a crime. I used the Feishu card message type to beautify the format. The comparison is as follows:

Original message format:
![WX20230906-180742@2x](https://github.com/walinejs/waline/assets/1457297/c3043c37-bf92-4d01-b499-f68f0b5fd4a9)

Beautified message format:
![WX20230906-180809@2x](https://github.com/walinejs/waline/assets/1457297/7b7b9ccc-5799-48ff-bc04-2616b6850532)

I feel much better about myself~_~

PS: The current defect is that the `LARK_TEMPLATE` message template cannot be used
