### PR TITLE
Fix: TypeError: Cannot use 'in' operator to search for 'updatedAt' in undefined

### DIFF
--- a/packages/server/src/service/storage/leancloud.js
+++ b/packages/server/src/service/storage/leancloud.js
@@ -405,15 +405,12 @@ module.exports = class extends Base {
       ret.map(async (item) => {
         const _oldStatus = item.get('status');
 
-        var newData
-        if (think.isFunction(data)) {
-          newData = data(item.toJSON())
+        var updateData = typeof data === 'function' ? data(item.toJSON()) : data;
+        if (updateData.hasOwnProperty('updatedAt')) {
+          delete updateData.updatedAt;
         }
-        if ('updatedAt' in newData) {
-          delete newData.updatedAt
-        }
-        item.set(newData)
-        
+        item.set(updateData);
+
         const _newStatus = item.get('status');
 
         if (_newStatus && _oldStatus !== _newStatus) {


### PR DESCRIPTION
TypeError: Cannot use 'in' operator to search for 'updatedAt' in undefined
    at /var/task/node_modules/@waline/vercel/src/service/storage/leancloud.js:412:25
    at Array.map (<anonymous>)
    at module.exports.update (/var/task/node_modules/@waline/vercel/src/service/storage/leancloud.js:405:11)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at module.exports.putAction (/var/task/node_modules/@waline/vercel/src/controller/comment.js:310:21)
    at cors (/var/task/node_modules/@koa/cors/index.js:108:16)
    at /var/task/node_modules/@waline/vercel/src/middleware/version.js:5:3
    at /var/task/node_modules/@waline/vercel/src/middleware/prefix-warning.js:27:3
    at Server.<anonymous> (/var/task/___vc/__launcher/helpers-UZ7RIBE7.js:1:7826)
    at Server.<anonymous> (/var/task/___vc/__launcher/__launcher.js:18:10973)
