### PR TITLE
fix: a minor change for fixing the warning causing from notifying by discord webhook

### DIFF
--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -389,7 +389,9 @@ module.exports = class extends think.Service {
       method: 'POST',
       header: form.getHeaders(),
       body: form,
-    }).then((resp) => resp.json());
+    }).then((resp) => resp.statusText);
+    // Expected return value: No Content
+    // Since Discord doesn't return any response body on success, we just return the status text.
   }
 
   async lark({ title, content }, self, parent) {


### PR DESCRIPTION
# 問題描述
若按照教學（[連結](https://waline.js.org/en/guide/features/notification.html#discord-notification)）使用 Discord Webhook, 當輸入評論時，視窗會跳出錯誤訊息 `Unexpected end of JSON input`。
# 問題機制
經查詢後，應該是 `waline/packages/server/src/service/notify.js` 中，fetch 回傳的 `resp` 中，body 是空的。
```
    return fetch(DISCORD_WEBHOOK, {
      method: 'POST',
      header: form.getHeaders(),
      body: form,
    }).then((resp) => resp.json());
```
若將 `(resp) => resp.json()` 改為 `(resp) => resp.text()`, 則回傳結果為 `''`

因此，當使用 `resp.json()` 時，報錯 `Unexpected end of JSON input`，推測應該是因為傳入的內容為空字串。
# 問題修復
經查詢後，回傳結果將會丟到變數 `discord` 中，並作為判斷是否要寄信的機制。
```
      if (
        [wechat, qq, telegram, qywxAmWechat, pushplus, discord, lark].every(
          think.isEmpty,
        )
      ) {
        mailList.push({ to: AUTHOR, title, content });
      }
```
因此，判斷 `discord` 中，只要有內容即可。
# 實際調整
將 `(resp) => resp.json()` 修改為 `(resp) => resp.statusText`，讓後續判讀是否要寄信時，`discord`變數中有資料。
（資料根據實際 Discord Webhook 回傳結果，應該會是 `No Content`

---
# Problem Description
If you use Discord Webhook according to the instructions ([Link](https://waline.js.org/en/guide/features/notification.html#discord-notification)), when entering a comment, the window will pop up with the error message `Unexpected end of JSON input`.
# Problem mechanism
After research, the issue might come from `waline/packages/server/src/service/notify.js`. When the `resp` returned by fetch, the body is empty.
```
     return fetch(DISCORD_WEBHOOK, {
       method: 'POST',
       header: form.getHeaders(),
       body: form,
     }).then((resp) => resp.json());
```
If `(resp) => resp.json()` is changed to `(resp) => resp.text()`, then the returned result will be `''`

Therefore, when using `resp.json()`, an error message `Unexpected end of JSON input` is reported, presumably because the input for the `.json()` is an empty string.
# Bug fix
According to the source code, the returned result will be stored in the variable `discord` and used as a mechanism to determine whether to send a letter.
```
       if (
         [wechat, qq, telegram, qywxAmWechat, pushplus, discord, lark].every(
           think.isEmpty,
         )
       ) {
         mailList.push({ to: AUTHOR, title, content });
       }
```
Therefore, I guess that the only requirement for variable `discord` is it supposes not to be empty.
# Change in source code
Modify `(resp) => resp.json()` to `(resp) => resp.statusText` so that there is data in the `discord` variable when subsequently judging whether to send a letter.
(The return value is based on the Discord Webhook return result, which should be `No Content`