### PR TITLE
更新文档独立部署的 docker compose || Update the document for independent deployment of docker compose

### DIFF
--- a/docs/src/guide/deploy/vps.md
+++ b/docs/src/guide/deploy/vps.md
@@ -47,7 +47,7 @@ services:
     image: lizheming/waline:latest
     restart: always
     ports:
-      - 127.0.0.1:8360:8360
+      - 8360:8360
     volumes:
       - ${PWD}/data:/app/data
     environment:


### PR DESCRIPTION
文档中提供的 docker compose，即
```yaml
# docker-compose.yml
version: '3'

services:
  waline:
    container_name: waline
    image: lizheming/waline:latest
    restart: always
    ports:
      - 127.0.0.1:8360:8360
    volumes:
      - ${PWD}/data:/app/data
    environment:
      TZ: 'Asia/Shanghai'
      SQLITE_PATH: '/app/data'
      JWT_TOKEN: 'Your token'
      SITE_NAME: 'Your site name'
      SITE_URL: 'https://example.com'
      SECURE_DOMAINS: 'example.com'
      AUTHOR_EMAIL: 'mail@example.com'
```
中的 ports 字段有问题，如果在本地部署，则无法从局域网中访问（实测），因此可以删除 127.0.0.1 前缀
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
The docker compose provided in the documentation is
```yaml
# docker-compose.yml
version: '3'

services:
  waline:
    container_name:waline
    image: lizheming/waline:latest
    restart: always
    ports:
      - 127.0.0.1:8360:8360
    volumes:
      - ${PWD}/data:/app/data
    environment:
      TZ: 'Asia/Shanghai'
      SQLITE_PATH: '/app/data'
      JWT_TOKEN: 'Your token'
      SITE_NAME: 'Your site name'
      SITE_URL: 'https://example.com'
      SECURE_DOMAINS: 'example.com'
      AUTHOR_EMAIL: 'mail@example.com'
```
There is a problem with the ports field in. If it is deployed locally, it cannot be accessed from the LAN (actual measurement), so you can delete the 127.0.0.1 prefix
