### PR TITLE
fix(server): #2502 , mail property undefined

### DIFF
--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -487,13 +487,14 @@ module.exports = class extends think.Service {
 
     const mailList = [];
     const isAuthorComment = AUTHOR
-      ? comment.mail.toLowerCase() === AUTHOR.toLowerCase()
+      ? (comment.mail || '').toLowerCase() === AUTHOR.toLowerCase()
       : false;
     const isReplyAuthor = AUTHOR
-      ? parent && parent.mail.toLowerCase() === AUTHOR.toLowerCase()
+      ? parent && (parent.mail || '').toLowerCase() === AUTHOR.toLowerCase()
       : false;
     const isCommentSelf =
-      parent && parent.mail.toLowerCase() === comment.mail.toLowerCase();
+      parent &&
+      (parent.mail || '').toLowerCase() === (comment.mail || '').toLowerCase();
 
     const title = mailSubjectAdmin || 'MAIL_SUBJECT_ADMIN';
     const content = mailTemplateAdmin || 'MAIL_TEMPLATE_ADMIN';


### PR DESCRIPTION
修复 mail 字段为 undefined 时的报错：

```
May 11 23:49:35 admired-nodes-1.localdomain node[160164]: TypeError: Cannot read property 'toLowerCase' of undefined
May 11 23:49:35 admired-nodes-1.localdomain node[160164]:     at module.exports.run (/root/waline/node_modules/@waline/vercel/src/service/notify.js:88:67)
May 11 23:49:35 admired-nodes-1.localdomain node[160164]:     at module.exports.postAction (/root/waline/node_modules/@waline/vercel/src/controller/comment.js:203:20)
May 11 23:49:35 admired-nodes-1.localdomain node[160164]:     at cors (/root/waline/node_modules/@koa/cors/index.js:110:16)
```