### PR TITLE
feat: add reply_user to WalineChildComment

### DIFF
--- a/packages/api/src/typings.ts
+++ b/packages/api/src/typings.ts
@@ -217,6 +217,15 @@ export interface WalineChildComment extends BaseWalineResponseComment {
    */
   // TODO: Support this field
   at?: string;
+
+  /**
+   * Reply user information
+   */
+  reply_user: {
+    nick: string;
+    link: string;
+    avatar: string;
+  };
 }
 
 export interface WalineRootComment extends BaseWalineResponseComment {

--- a/packages/api/src/typings.ts
+++ b/packages/api/src/typings.ts
@@ -221,7 +221,7 @@ export interface WalineChildComment extends BaseWalineResponseComment {
   /**
    * Reply user information
    */
-  reply_user: {
+  reply_user?: {
     nick: string;
     link: string;
     avatar: string;


### PR DESCRIPTION
`reply_user` is being used in [CommentCard.vue](https://github.com/walinejs/waline/blob/100332388ef704466d59174e0fc354962ef132b8/packages/client/src/components/CommentCard.vue#L192) but not included in types.

See also: https://github.com/walinejs/waline/blob/100332388ef704466d59174e0fc354962ef132b8/packages/server/src/controller/comment.js#L583-L588