### PR TITLE
fix(client): update sass functions to use new module syntax

### DIFF
--- a/packages/client/src/styles/helpers/_svg.scss
+++ b/packages/client/src/styles/helpers/_svg.scss
@@ -5,9 +5,9 @@
   $index: string.index($string, $search);
   @return if(
     $index,
-    str-slice($string, 1, $index - 1) + $replace +
+    string.slice($string, 1, $index - 1) + $replace +
       string-replace(
-        str-slice($string, $index + str-length($search)),
+        string.slice($string, $index + string.length($search)),
         $search,
         $replace
       ),
@@ -21,7 +21,7 @@
   $index: 0;
   $loops: math.ceil(math.div(string.length($svg), $slice));
 
-  @if not str-index($svg, xmlns) {
+  @if not string.index($svg, xmlns) {
     $svg: string-replace(
       $svg,
       '<svg',


### PR DESCRIPTION
- Replace str-index with string.index
- Replace str-slice with string.slice
- Replace str-length with string.length

These changes address deprecation warnings from Dart Sass 3.0.0