### PR TITLE
feat(notify): support qywx api proxy

### DIFF
--- a/docs/src/guide/features/notification.md
+++ b/docs/src/guide/features/notification.md
@@ -69,6 +69,8 @@ ww479cadfqfe8c151f,MPKN9gX97w4e4b4h4u7u4i4i4i4iO6mN_dDedBFzqC5c,@all,1000002,2S8
 [参考文档 1](https://note.youdao.com/ynoteshare/index.html?id=351e08a72378206f9dd64d2281e9b83b&type=note&_time=1642141216026) | [参考文档 2](https://note.youdao.com/ynoteshare1/index.html?id=1a0c8aff284ad28cbd011b29b3ad0191&type=note)
 
 - `QYWX_AM`: 用于发送企业应用消息的变量，必填。
+- `QYWX_PROXY`: 指定企业微信接口的反向代理服务器地址（可信IP），未配置则不使用代理。
+- `QYWX_PROXY_PORT`: 指定企业微信接口的反向代理服务器端口（默认 80）
 - `AUTHOR_EMAIL`: 博主邮箱，用来区分发布的评论是否是博主本身发布的。如果是博主发布的则不进行提醒通知。
 - `SITE_NAME`: 网站名称，用于在消息中显示。
 - `SITE_URL`: 网站地址，用于在消息中显示。

--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -111,7 +111,7 @@ module.exports = class extends think.Service {
   }
 
   async qywxAmWechat({ title, content }, self, parent) {
-    const { QYWX_AM, SITE_NAME, SITE_URL } = process.env;
+    const { QYWX_AM, QYWX_PROXY, QYWX_PROXY_PORT, SITE_NAME, SITE_URL } = process.env;
 
     if (!QYWX_AM) {
       return false;
@@ -136,6 +136,7 @@ module.exports = class extends think.Service {
         postUrl: SITE_URL + self.url + '#' + self.objectId,
       },
     };
+
     const contentWechat =
       think.config('WXTemplate') ||
       `💬 {{site.name|safe}}的文章《{{postName}}》有新评论啦 
@@ -154,8 +155,17 @@ module.exports = class extends think.Service {
     querystring.set('corpid', `${QYWX_AM_AY[0]}`);
     querystring.set('corpsecret', `${QYWX_AM_AY[1]}`);
 
+    let baseUrl = 'https://qyapi.weixin.qq.com';
+    if (QYWX_PROXY) {
+      if (!QYWX_PROXY_PORT) {
+        baseUrl = `http://${QYWX_PROXY}`;
+      } else {
+        baseUrl = `http://${QYWX_PROXY}:${QYWX_PROXY_PORT}`;
+      }
+    }
+
     const { access_token } = await fetch(
-      `https://qyapi.weixin.qq.com/cgi-bin/gettoken?${querystring.toString()}`,
+      `${baseUrl}/cgi-bin/gettoken?${querystring.toString()}`,
       {
         headers: {
           'content-type': 'application/json',
@@ -164,7 +174,7 @@ module.exports = class extends think.Service {
     ).then((resp) => resp.json());
 
     return fetch(
-      `https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token=${access_token}`,
+      `${baseUrl}/cgi-bin/message/send?access_token=${access_token}`,
       {
         method: 'POST',
         headers: {


### PR DESCRIPTION
如果使用 Vercel 作为服务端，企业微信应用的可信 IP 就难以稳定设置（自部署在公网服务器的则不会碰到这种情况），因此目前常见的策略是使用一台公网 IP 服务器作为企业微信 API 的反向代理，并需要将此代理服务器添加到可信 IP.

Refs: #2753 #2661

以下是新引入的两个环境变量的简明文档：

[QYWX_PROXY]
用途: 指定企业微信接口的反向代理服务器地址（可信IP），未配置则不使用代理。
示例: 123.213.132.231
说明: 当设置此变量时，所有对企业微信 API 的请求将通过该代理服务器进行转发。

[QYWX_PROXY_PORT]
用途: 指定企业微信接口的反向代理服务器端口（默认 80）
示例: 8080
说明: 如果 [QYWX_PROXY] 设置了但未指定端口号，则使用此变量指定的端口号。如果未设置此变量，则默认使用 80 端口。

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
If Vercel is used as the server, the trusted IP of the enterprise WeChat application will be difficult to stably set (this situation will not happen if it is self-deployed on a public network server). Therefore, the current common strategy is to use a public network IP server as Reverse proxy for Enterprise WeChat API and need to add this proxy server to the trusted IP.

Refs: #2753 #2661

The following is concise documentation of the two newly introduced environment variables:

[QYWX_PROXY]
Purpose: Specify the reverse proxy server address (trusted IP) of the enterprise WeChat interface. If not configured, the proxy will not be used.
Example: 123.213.132.231
Description: When this variable is set, all requests to the Enterprise WeChat API will be forwarded through this proxy server.

[QYWX_PROXY_PORT]
Purpose: Specify the reverse proxy server port of the enterprise WeChat interface (default 80)
Example: 8080
Description: If [QYWX_PROXY] is set but no port number is specified, the port number specified by this variable is used. If this variable is not set, port 80 is used by default.
