### PR TITLE
Add Indexes to Waline SQL table

### DIFF
--- a/assets/waline.sql
+++ b/assets/waline.sql
@@ -30,6 +30,13 @@ CREATE TABLE `wl_Comment` (
   `createdAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updatedAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
+  ADD INDEX `idx_comment_url` (`url`),
+  ADD INDEX `idx_comment_user_id` (`user_id`),
+  ADD INDEX `idx_comment_status` (`status`),
+  ADD INDEX `idx_comment_pid_rid` (`pid`, `rid`),
+  ADD INDEX `idx_comment_created_at` (`createdAt`),
+  ADD INDEX `idx_comment_updated_at` (`updatedAt`),
+  ADD INDEX `idx_comment_sticky` (`sticky`);
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
@@ -53,6 +60,9 @@ CREATE TABLE `wl_Counter` (
   `createdAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updatedAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
+  ADD INDEX `idx_counter_url` (`url`),
+  ADD INDEX `idx_counter_time` (`time`),
+  ADD INDEX `idx_counter_created_at` (`createdAt`);
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
@@ -79,6 +89,9 @@ CREATE TABLE `wl_Users` (
   `createdAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updatedAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)
+  ADD UNIQUE INDEX `idx_user_email` (`email`),
+  ADD INDEX `idx_user_type` (`type`),
+  ADD INDEX `idx_user_created_at` (`createdAt`);
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 


### PR DESCRIPTION
### Added Indexes Explanation

1. **`wl_Comment` Table**:
   - `idx_comment_url`: Speeds up filtering comments by `url`.
   - `idx_comment_user_id`: Improves queries filtering by `user_id`.
   - `idx_comment_status`: Useful for filtering by `status` (e.g., fetching only "approved" comments).
   - `idx_comment_pid_rid`: Helps when fetching replies using `pid` and `rid`.
   - `idx_comment_created_at` and `idx_comment_updated_at`: Useful for ordering or filtering based on date ranges.
   - `idx_comment_sticky`: Optimizes filtering by `sticky` flag.

2. **`wl_Counter` Table**:
   - `idx_counter_url`: Useful when counting reactions for specific URLs.
   - `idx_counter_time`: Helps optimize time-based queries.
   - `idx_counter_created_at`: Useful for sorting or filtering by creation date.

3. **`wl_Users` Table**:
   - `idx_user_email`: A unique index on `email` ensures fast lookups and maintains uniqueness.
   - `idx_user_type`: Useful for filtering by user type (e.g., "administrator", "guest").
   - `idx_user_created_at`: Optimizes sorting or filtering by registration date.