### PR TITLE
chore: bump patched version enabling #2802

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@waline/vercel",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "description": "vercel server for waline comment system",
   "keywords": [
     "waline",


### PR DESCRIPTION
在 #2802 中，对 waline 企业微信推送的功能进行了 vercel server 条件下的修补完善（支持填入反向代理），此 PR 以便于维护者决定是否需要根据此改动发布新的 patch 版本，使得在生产环境中生效。因为上一次版本发布距今已有数月，固此改动未并入上一个 #2802 .
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
In #2802, the function of waline enterprise WeChat push has been patched and improved under vercel server conditions (supports filling in reverse proxy). This PR allows the maintainer to decide whether to release a new patch version based on this change, so that in Effective in production environment. Because it has been several months since the last version was released, this change has not been incorporated into the previous #2802.
