### PR TITLE
fix: prevent child element overflow by adding box-sizing: border-box

### DIFF
--- a/packages/client/src/styles/panel.scss
+++ b/packages/client/src/styles/panel.scss
@@ -156,7 +156,7 @@
   position: relative;
 
   resize: vertical;
-
+  box-sizing: border-box;
   width: calc(100% - 1em);
   min-height: 8.75em;
   margin: 0.75em 0.5em;


### PR DESCRIPTION
- Added box-sizing: border-box to fix container overflow issues
- Ensures padding and border are included in element's total width/height calculation