### PR TITLE
fix(admin): the api path is the same as in the documentation

### DIFF
--- a/packages/admin/src/pages/profile/index.jsx
+++ b/packages/admin/src/pages/profile/index.jsx
@@ -230,7 +230,7 @@ export default function () {
                             href={
                               user[social]
                                 ? `https://${social}.com/${user[social]}`
-                                : `${baseUrl}oauth/?type=${social}&state=${token}`
+                                : `${baseUrl}oauth?type=${social}&state=${token}`
                             }
                             target={user[social] ? '_blank' : '_self'}
                             rel="noreferrer"


### PR DESCRIPTION
This pr ensures that the corrected url and document remain consistent without affecting functionality

`http://127.0.0.1:8360/api/oauth/`->`http://127.0.0.1:8360/api/oauth`