### PR TITLE
Fix waline.sql: A critical syntax error in the SQL file

### DIFF
--- a/assets/waline.sql
+++ b/assets/waline.sql
@@ -9,6 +9,7 @@ SET NAMES utf8mb4;
 
 
 # Dump of table wl_Comment
+DROP TABLE IF EXISTS `wl_Comment`;
 # ------------------------------------------------------------
 
 CREATE TABLE `wl_Comment` (
@@ -29,19 +30,20 @@ CREATE TABLE `wl_Comment` (
   `url` varchar(255) DEFAULT NULL,
   `createdAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updatedAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
-  ADD INDEX `idx_comment_url` (`url`),
-  ADD INDEX `idx_comment_user_id` (`user_id`),
-  ADD INDEX `idx_comment_status` (`status`),
-  ADD INDEX `idx_comment_pid_rid` (`pid`, `rid`),
-  ADD INDEX `idx_comment_created_at` (`createdAt`),
-  ADD INDEX `idx_comment_updated_at` (`updatedAt`),
-  ADD INDEX `idx_comment_sticky` (`sticky`);
+  PRIMARY KEY (`id`),
+  INDEX `idx_comment_url` (`url`),
+  INDEX `idx_comment_user_id` (`user_id`),
+  INDEX `idx_comment_status` (`status`),
+  INDEX `idx_comment_pid_rid` (`pid`, `rid`),
+  INDEX `idx_comment_created_at` (`createdAt`),
+  INDEX `idx_comment_updated_at` (`updatedAt`),
+  INDEX `idx_comment_sticky` (`sticky`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 
 # Dump of table wl_Counter
+DROP TABLE IF EXISTS `wl_Counter`;
 # ------------------------------------------------------------
 
 CREATE TABLE `wl_Counter` (
@@ -59,15 +61,16 @@ CREATE TABLE `wl_Counter` (
   `url` varchar(255) NOT NULL DEFAULT '',
   `createdAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updatedAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
-  ADD INDEX `idx_counter_url` (`url`),
-  ADD INDEX `idx_counter_time` (`time`),
-  ADD INDEX `idx_counter_created_at` (`createdAt`);
+  PRIMARY KEY (`id`),
+  INDEX `idx_counter_url` (`url`),
+  INDEX `idx_counter_time` (`time`),
+  INDEX `idx_counter_created_at` (`createdAt`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 
 # Dump of table wl_Users
+DROP TABLE IF EXISTS `wl_Users`;
 # ------------------------------------------------------------
 
 CREATE TABLE `wl_Users` (
@@ -88,10 +91,10 @@ CREATE TABLE `wl_Users` (
   `2fa` varchar(32) DEFAULT NULL,
   `createdAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
   `updatedAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
-  ADD UNIQUE INDEX `idx_user_email` (`email`),
-  ADD INDEX `idx_user_type` (`type`),
-  ADD INDEX `idx_user_created_at` (`createdAt`);
+  PRIMARY KEY (`id`),
+  UNIQUE INDEX `idx_user_email` (`email`),
+  INDEX `idx_user_type` (`type`),
+  INDEX `idx_user_created_at` (`createdAt`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 


### PR DESCRIPTION
我自建 [MySQL](https://waline.js.org/guide/database.html#mysql) 数据库时,根据指引导入 [wline.sql](https://github.com/walinejs/waline/blob/main/assets/waline.sql) 文件后出错:

```
[SQL] Query waline start
[ERR] 1064 - You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'ADD INDEX `idx_comment_url` (`url`),
  ADD INDEX `idx_comment_user_id` (`user_id' at line 23
[ERR] # Dump of table wl_Comment
# ------------------------------------------------------------

CREATE TABLE `wl_Comment` (
  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
  `user_id` int(11) DEFAULT NULL,
  `comment` text,
  `insertedAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
  `ip` varchar(100) DEFAULT '',
  `link` varchar(255) DEFAULT NULL,
  `mail` varchar(255) DEFAULT NULL,
  `nick` varchar(255) DEFAULT NULL,
  `pid` int(11) DEFAULT NULL,
  `rid` int(11) DEFAULT NULL,
  `sticky` boolean DEFAULT NULL,
  `status` varchar(50) NOT NULL DEFAULT '',
  `like` int(11) DEFAULT NULL,
  `ua` text,
  `url` varchar(255) DEFAULT NULL,
  `createdAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
  `updatedAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`)
  ADD INDEX `idx_comment_url` (`url`),
  ADD INDEX `idx_comment_user_id` (`user_id`),
  ADD INDEX `idx_comment_status` (`status`),
  ADD INDEX `idx_comment_pid_rid` (`pid`, `rid`),
  ADD INDEX `idx_comment_created_at` (`createdAt`),
  ADD INDEX `idx_comment_updated_at` (`updatedAt`),
  ADD INDEX `idx_comment_sticky` (`sticky`)
[SQL] Process terminated
```

这是因为非法的SQL语句, `ADD INDEX`不能在创建表时创建索引.应使用 `INDEX`.

the `ADD INDEX` statements should be placed outside the `CREATE TABLE` block, or they should be included within the table definition using the correct syntax.

我修改了这部分语句,改为正确的语法,并且增加了
```sql
DROP TABLE IF EXISTS `wl_Comment`;
DROP TABLE IF EXISTS `wl_Counter`;
DROP TABLE IF EXISTS `wl_Users`;
```
避免与数据库中已经创建的表冲突.

现在该sql文件可以正常导入运行.

---

Description
This PR fixes a critical syntax error in the SQL schema definitions that caused the CREATE TABLE statements to fail during database initialization. The changes ensure compatibility with MySQL syntax and improve the overall reliability of table creation.

Key Changes:
Syntax Correction:

- Removed invalid ADD INDEX clauses from CREATE TABLE statements.

- Defined indexes directly within the CREATE TABLE block using comma-separated syntax (e.g., INDEX idx_name (column)).

Added DROP TABLE IF EXISTS before each CREATE TABLE to prevent conflicts with existing tables.