### PR TITLE
fix: route to robots.txt

### DIFF
--- a/example/vercel.json
+++ b/example/vercel.json
@@ -11,7 +11,7 @@
   ],
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/((?!robots\\.txt$).*)",
       "destination": "index.cjs"
     }
   ]


### PR DESCRIPTION
起因是我发现用vercel一键部署的站点的**waline**评论系统的链接被搜索引擎索引了，单独的评论区前端页面不应该被索引的，看了一下链接发现没有`robots.txt`,但是看vercel控制台发现资源是有`robots.txt`文件的，应该是路由问题，改一下vercel配置就正常了
![截图 2025-06-10 14-06-04 (1)](https://github.com/user-attachments/assets/3a3b0432-b5d5-4041-af19-1dd0280ec061)

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
The reason is that I found that the link to the **waline** comment system of the site deployed with vercel is indexed by search engines. The front-end page of the separate comment area should not be indexed. After looking at the link, I found that there is no `robots.txt`, but looking at the vercel console, I found that the resource has `robots.txt` file, which should be a routing problem. It will be normal to change the vercel configuration.
![Screenshot 2025-06-10 14-06-04 (1)](https://github.com/user-attachments/assets/3a3b0432-b5d5-4041-af19-1dd0280ec061)
