### PR TITLE
docs: add waline-openai-moderation plugin to the list

### DIFF
--- a/docs/src/en/reference/server/plugin.md
+++ b/docs/src/en/reference/server/plugin.md
@@ -94,3 +94,4 @@ Welcome to submit plugins~
 - [waline-notification-wecom-group-bot](https://github.com/wnwd/waline-notification-wecom-group-bot)
 - [waline-notification-lark-group-bot](https://github.com/wnwd/waline-notification-lark-group-bot)
 - [waline-notification-slack-app](https://github.com/wnwd/waline-notification-slack-app)
+- [waline-openai-moderation](https://github.com/chenxv399/waline-openai-moderation)

--- a/docs/src/reference/server/plugin.md
+++ b/docs/src/reference/server/plugin.md
@@ -94,3 +94,4 @@ module.exports = {
 - [waline-notification-wecom-group-bot](https://github.com/wnwd/waline-notification-wecom-group-bot)
 - [waline-notification-lark-group-bot](https://github.com/wnwd/waline-notification-lark-group-bot)
 - [waline-notification-slack-app](https://github.com/wnwd/waline-notification-slack-app)
+- [waline-openai-moderation](https://github.com/chenxv399/waline-openai-moderation)


### PR DESCRIPTION
docs(server): 添加 waline-openai-moderation 插件到官方文档

- 在英文和中文文档中添加了新的 waline-openai-moderation 插件链接