### PR TITLE
style: Display replied user‘s nickname and comment inline || style: Display replied user's nickname and comment inline

### DIFF
--- a/packages/client/src/styles/card.scss
+++ b/packages/client/src/styles/card.scss
@@ -217,10 +217,19 @@
 
     > *:first-child {
       margin-top: 0;
+      display: inline;
     }
 
     > *:last-child {
       margin-bottom: 0;
+    }
+
+    div {
+      display: inline;
+      
+      > p {
+        display: inline;
+      }
     }
   }
 


### PR DESCRIPTION
回复头和回复内容还是放在同一行看着舒服。当然，看官方的选择啦。


<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
It is still comfortable to put the reply head and reply content in the same line. Of course, it depends on the official choice.
