### PR TITLE
fix: qq notify request error(btwaf is from-data error)

### DIFF
--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -213,18 +213,29 @@ module.exports = class extends think.Service {
 {{self.comment}}
 仅供预览评论，请前往上述页面查看完整內容。`;
 
-    const form = new FormData();
-
-    form.append('msg', this.controller.locale(contentQQ, data));
-    form.append('qq', QQ_ID);
-
     const qmsgHost = QMSG_HOST ? QMSG_HOST.replace(/\/$/, '') : 'https://qmsg.zendee.cn';
+
+    const postBodyData = {
+      qq: QQ_ID,
+      msg: this.controller.locale(contentQQ, data),
+    };
+    const postBody = Object.keys(postBodyData)
+      .map((key) => encodeURIComponent(key) + '=' + encodeURIComponent(postBodyData[key]))
+      .join('&');
 
     return fetch(`${qmsgHost}/send/${QMSG_KEY}`, {
       method: 'POST',
-      headers: form.getHeaders(),
-      body: form,
-    }).then((resp) => resp.json());
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: postBody,
+    }).then((resp) => {
+      return resp.json().then((json) => {
+        think.logger.debug(`qq notify response: ${JSON.stringify(json)}`);
+
+        return json;
+      });
+    });
   }
 
   async telegram(self, parent) {


### PR DESCRIPTION
本地调试QQ通知，发现接口响应返回的信息是:`btwaf is from-data error`，初步怀疑是该接口服务器拦截了，所以改成`x-www-form-urlencoded`，修改后本地调试正常。
<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
After local debugging QQ notification, it was found that the information returned by the interface response was: `btwaf is from-data error`. It was initially suspected that the interface server had intercepted it, so it was changed to `x-www-form-urlencoded`. After the modification, local debugging was normal.
