### PR TITLE
fix: wordLimit logic in CommentBox.

### DIFF
--- a/packages/client/src/components/CommentBox.vue
+++ b/packages/client/src/components/CommentBox.vue
@@ -443,12 +443,6 @@ watchImmediate([config, wordNumber], ([config, wordNumber]) => {
   const { wordLimit: limit } = config;
 
   if (limit) {
-    // [0, 0] => no limit
-    if (limit[0] === 0 && limit[1] === 0) {
-      wordLimit.value = 0;
-      isWordNumberLegal.value = true;
-      return;
-    }
     if (wordNumber < limit[0] && limit[0] !== 0) {
       [wordLimit.value] = limit;
       isWordNumberLegal.value = false;
@@ -676,7 +670,7 @@ onMounted(() => {
           <div class="wl-text-number">
             {{ wordNumber }}
 
-            <span v-if="config.wordLimit && !(config.wordLimit[0] === 0 && config.wordLimit[1] === 0)">
+            <span v-if="config.wordLimit">
               &nbsp;/&nbsp;
               <span :class="{ illegal: !isWordNumberLegal }" v-text="wordLimit" />
             </span>

--- a/packages/client/src/utils/config.ts
+++ b/packages/client/src/utils/config.ts
@@ -50,7 +50,7 @@ export const getServerURL = (serverURL: string): string => {
 };
 
 const getWordLimit = (wordLimit: WalineProps['wordLimit']): [number, number] | false =>
-  Array.isArray(wordLimit) ? wordLimit : typeof wordLimit === 'number' ? [0, wordLimit] : false;
+  Array.isArray(wordLimit) ? wordLimit : typeof wordLimit === 'number' && wordLimit > 0 ? [0, wordLimit] : false;
 
 const fallback = <T = unknown>(value: T | boolean | undefined, fallback: T): T | null =>
   value == null || value === true ? fallback : value === false ? null : value;


### PR DESCRIPTION
Add condition to handle no word limit scenario in CommentBox.

-----

When wordLimit in client is set to '0', the code below will extend it to '[0, 0]', which should mean 'no limit' as the most document in this repo demonstrares: 

https://github.com/walinejs/waline/blob/5a226db1e6bca7789646a9889e91cce928a4aaa0/packages/client/src/utils/config.ts#L53

However, the code in CommentBox mistakenly handles the uplimit, leading to an error below when a user submit a comment:

```
评论字数应在 0 到 0 字之间！
当前字数：8
```

To fix that, we added a check.
