### PR TITLE
feat: add 'ugc' to link rel attributes

### DIFF
--- a/packages/client/src/components/CommentCard.vue
+++ b/packages/client/src/components/CommentCard.vue
@@ -89,7 +89,7 @@ const isEditingCurrent = computed(() => comment.objectId === edit?.objectId);
           class="wl-nick"
           :href="link"
           target="_blank"
-          rel="nofollow noopener noreferrer"
+          rel="ugc nofollow noreferrer noopener"
           >{{ comment.nick }}</a
         >
 

--- a/packages/server/__tests__/xss.spec.js
+++ b/packages/server/__tests__/xss.spec.js
@@ -71,10 +71,10 @@ Waline is a good framework. :money:
 
   it('Should resolve links', () => {
     expect(parser('[link](https://example.com)')).toEqual(
-      '<p><a href="https://example.com" target="_blank" rel="nofollow noreferrer noopener">link</a></p>\n',
+      '<p><a href="https://example.com" target="_blank" rel="ugc nofollow noreferrer noopener">link</a></p>\n',
     );
     expect(parser('<p><a href="https://example.com" rel="opener prefetch">link</a></p>')).toEqual(
-      '<p><a href="https://example.com" rel="nofollow noreferrer noopener" target="_blank">link</a></p>',
+      '<p><a href="https://example.com" rel="ugc nofollow noreferrer noopener" target="_blank">link</a></p>',
     );
   });
 

--- a/packages/server/src/service/markdown/xss.js
+++ b/packages/server/src/service/markdown/xss.js
@@ -12,13 +12,13 @@ DOMPurify.addHook('uponSanitizeElement', (node, data) => {
 
 /**
  * Add a hook to make all links open a new window
- * and force their rel to be 'nofollow noreferrer noopener'
+ * and force their rel to be 'ugc nofollow noreferrer noopener'
  */
 DOMPurify.addHook('afterSanitizeAttributes', (node) => {
   // set all elements owning target to target=_blank
   if ('target' in node && node.href && !node.href.startsWith('about:blank#')) {
     node.setAttribute('target', '_blank');
-    node.setAttribute('rel', 'nofollow noreferrer noopener');
+    node.setAttribute('rel', 'ugc nofollow noreferrer noopener');
   }
 
   // set non-HTML/MathML links to xlink:show=new


### PR DESCRIPTION
- `+ ugc` 符合最新语义（Google 自 2019） 

我调查了下其他的
- twikoo 是 noopener noreferrer nofollow ugc
- artalk 是 noreferrer noopener nofollow
- valine 是 noopener

相关文档：
- nofollow 和 ugc 一起用以保证兼容性：https://developers.google.com/search/blog/2019/09/evolving-nofollow-new-ways-to-identify?hl=zh-cn#can-i-use-more-than-one-rel-value-on-a-link
- 几个用于出站链接的 rel 值（sponsored，ugc，nofollow）介绍：https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links?hl=zh-cn 

<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
- `+ugc` conforms to the latest semantics (Google since 2019)

I looked into other
- twikoo is noopener noreferrer nofollow ugc
- artalk is noreferrer noopener nofollow
- valine is a noopener

Related documents:
- nofollow and ugc are used together to ensure compatibility: https://developers.google.com/search/blog/2019/09/evolving-nofollow-new-ways-to-identify?hl=zh-cn#can-i-use-more-than-one-rel-value-on-a-link
- Introduction to several rel values (sponsored, ugc, nofollow) for outbound links: https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links?hl=zh-cn
