### PR TITLE
Update ip2region dependency to github.com/lizheming/node-ip2region/tree/fix/bundle-data

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -31,7 +31,7 @@
     "dompurify": "^3.4.2",
     "fast-csv": "^5.0.7",
     "form-data": "^4.0.5",
-    "ip2region": "^2.3.0",
+    "ip2region": "github:lizheming/node-ip2region#fix/bundle-data",
     "jsdom": "^19.0.0",
     "jsonwebtoken": "^9.0.3",
     "koa-compose": "^4.1.0",


### PR DESCRIPTION
The server deployed in Vercel not display the IP location, 上游 ip2region 迟迟不合并代码，

https://github.com/yourtion/node-ip2region/pull/36

建议先使用已修复的分支。

警告：本 PR 未经测试。需要处理 pnpm 问题