### PR TITLE
fix(component): Fixed "search" option's value for components init.

### DIFF
--- a/packages/client/src/typings/waline.d.ts
+++ b/packages/client/src/typings/waline.d.ts
@@ -232,7 +232,7 @@ export interface WalineProps {
    *
    * Customize Search feature
    */
-  search?: WalineSearchOptions;
+  search?: WalineSearchOptions | boolean;
 
   /**
    * 代码块高亮器


### PR DESCRIPTION
Fixed the problem which will cause this:

<img width="1760" height="123" alt="image" src="https://github.com/user-attachments/assets/6993481c-60f6-459a-8e93-42fcbf7cd07d" />


<img width="1780" height="952" alt="image" src="https://github.com/user-attachments/assets/52a7d2e9-0998-4130-a492-178203117e9b" />
