### PR TITLE
tests(server): add GET /api/comment test and Comment model stub; fix test description casing

### DIFF
--- a/packages/server/__tests__/token.spec.js
+++ b/packages/server/__tests__/token.spec.js
@@ -22,6 +22,13 @@ const main = require('../index.js');
 // Use a custom model stub so no real database connection is needed
 const handler = main({
   customModel: (modelName) => {
+    if (modelName === 'Comment') {
+      return {
+        select: async () => [],
+        count: async () => 0,
+      };
+    }
+
     if (modelName === 'Users') {
       return {
         select: async () => [],
@@ -62,7 +69,7 @@ const apiRequest = (method, path, body) => {
   return fetch(url, options).then((r) => r.json());
 };
 
-describe('gET /api/token', () => {
+describe('GET /api/token', () => {
   it('should return empty user info when not authenticated', async () => {
     const body = await apiRequest('GET', '/api/token');
     expect(body.errno).toBe(0);
@@ -70,7 +77,21 @@ describe('gET /api/token', () => {
   });
 });
 
-describe('pOST /api/token', () => {
+describe('GET /api/comment', () => {
+  it('should return an empty comment list for a running server', async () => {
+    const body = await apiRequest('GET', '/api/comment?path=/unit-test');
+
+    expect(body.errno).toBe(0);
+    expect(body.data).toMatchObject({
+      page: 1,
+      pageSize: 10,
+      count: 0,
+      data: [],
+    });
+  });
+});
+
+describe('POST /api/token', () => {
   it('should return a validation error when email is missing', async () => {
     const body = await apiRequest('POST', '/api/token', { password: 'password123' });
     expect(body.errno).toBe(1001);


### PR DESCRIPTION
### Motivation
- Add coverage for the `/api/comment` endpoint and ensure the server returns an empty list when no comments exist.
- Prevent tests from touching a real database by providing a `Comment` model stub in the test harness.
- Clean up test suite descriptions to use consistent casing for readability.

### Description
- Add a `Comment` stub to the test `customModel` that implements `select` and `count` to avoid real DB access.
- Add a `GET /api/comment` test that asserts the response contains pagination metadata and an empty `data` list.
- Fix test description strings from `'gET /api/token'`/`'pOST /api/token'` to `'GET /api/token'` and reintroduce the `POST /api/token` describe block.

### Testing
- Ran the server test file with `vitest` targeting `packages/server/__tests__/token.spec.js`.
- All tests in the modified file completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a316145e7608326836f338b6c792d19)