### PR TITLE
Add Vercel runtime fixture and integration tests

### DIFF
--- a/packages/server/__tests__/fixtures/vercel/index.cjs
+++ b/packages/server/__tests__/fixtures/vercel/index.cjs
@@ -1,0 +1,74 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const createApplication = require('../../..');
+
+const storePath =
+  process.env.WALINE_TEST_COMMENT_STORE || path.join('/tmp', 'waline-vercel-comments.json');
+
+const readComments = () => {
+  try {
+    return JSON.parse(fs.readFileSync(storePath, 'utf8'));
+  } catch {
+    return [];
+  }
+};
+
+const writeComments = (comments) => {
+  fs.writeFileSync(storePath, JSON.stringify(comments), 'utf8');
+};
+
+const matchValue = (actual, expected) => {
+  if (Array.isArray(expected)) {
+    const [operator, value] = expected;
+
+    if (operator === 'NOT IN') return !value.includes(actual);
+    if (operator === 'IN') return value.includes(actual);
+    if (operator === '>') return new Date(actual).getTime() > new Date(value).getTime();
+  }
+
+  return actual === expected;
+};
+
+const matchesWhere = (comment, where = {}) =>
+  Object.entries(where).every(([key, value]) => {
+    if (key === '_complex') return true;
+    if (value === undefined) return comment[key] === undefined;
+
+    return matchValue(comment[key], value);
+  });
+
+const createCommentModel = () => ({
+  add: async (comment) => {
+    const comments = readComments();
+    const savedComment = {
+      ...comment,
+      objectId: `vercel-comment-${comments.length + 1}`,
+      insertedAt: new Date(comment.insertedAt).toISOString(),
+    };
+
+    comments.push(savedComment);
+    writeComments(comments);
+
+    return savedComment;
+  },
+  select: async (where = {}) => readComments().filter((comment) => matchesWhere(comment, where)),
+  count: async (where = {}) =>
+    readComments().filter((comment) => matchesWhere(comment, where)).length,
+});
+
+module.exports = createApplication({
+  customModel: (modelName) => {
+    if (modelName === 'Comment') return createCommentModel();
+
+    if (modelName === 'Users') {
+      return {
+        select: async () => [],
+        add: async () => ({}),
+        update: async () => null,
+        delete: async () => null,
+        count: async () => 0,
+      };
+    }
+  },
+});

--- a/packages/server/__tests__/fixtures/vercel/vercel.json
+++ b/packages/server/__tests__/fixtures/vercel/vercel.json
@@ -1,0 +1,21 @@
+{
+  "name": "waline-vercel-test",
+  "env": {
+    "NODE_OPTIONS": "--experimental-require-module"
+  },
+  "builds": [
+    {
+      "src": "index.cjs",
+      "use": "@vercel/node",
+      "config": {
+        "helpers": false
+      }
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "index.cjs"
+    }
+  ]
+}

--- a/packages/server/__tests__/vercel.spec.js
+++ b/packages/server/__tests__/vercel.spec.js
@@ -1,0 +1,178 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { createServer } from 'node:http';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const fixturePath = new URL('fixtures/vercel', import.meta.url).pathname;
+
+let oauthServiceStub;
+let oauthServiceUrl;
+let vercelProcess;
+let vercelPort;
+let output = '';
+const commentStorePath = `/tmp/test-waline-vercel-comments-${process.pid}.json`;
+const testPath = `/vercel-unit-test-${process.pid}`;
+
+const listen = async (server) => {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  return server.address().port;
+};
+
+const getFreePort = async () => {
+  const server = createServer();
+  const port = await listen(server);
+
+  await new Promise((resolve) => {
+    server.close(resolve);
+  });
+
+  return port;
+};
+
+const getVercelUrl = () => `http://127.0.0.1:${vercelPort}`;
+
+const waitForVercel = async () => {
+  const deadline = Date.now() + 60_000;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(
+        `${getVercelUrl()}/api/comment?path=${encodeURIComponent(testPath)}`,
+        {
+          signal: AbortSignal.timeout(10_000),
+        },
+      );
+
+      if (response.ok) return response;
+    } catch {
+      // Vercel may still be compiling the serverless function.
+    }
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 500);
+    });
+  }
+
+  throw new Error(`Vercel dev server did not become ready. Output:\n${output}`);
+};
+
+beforeAll(async () => {
+  // Waline fetches the OAuth service list on every request. Stub it locally so
+  // the Vercel runtime test does not depend on the public OAuth service/network.
+  oauthServiceStub = createServer((_req, res) => {
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ services: [] }));
+  });
+  const oauthPort = await listen(oauthServiceStub);
+
+  oauthServiceUrl = `http://127.0.0.1:${oauthPort}`;
+  vercelPort = await getFreePort();
+
+  vercelProcess = spawn(
+    'vercel',
+    ['dev', fixturePath, '--local', '--yes', '--listen', `127.0.0.1:${vercelPort}`],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        JWT_TOKEN: 'test-jwt-secret',
+        OAUTH_URL: oauthServiceUrl,
+        AKISMET_KEY: 'false',
+        SQLITE_PATH: `/tmp/test-waline-vercel-${process.pid}.sqlite`,
+        WALINE_TEST_COMMENT_STORE: commentStorePath,
+      },
+    },
+  );
+
+  vercelProcess.stdout.on('data', (chunk) => {
+    output += chunk.toString();
+  });
+  vercelProcess.stderr.on('data', (chunk) => {
+    output += chunk.toString();
+  });
+}, 70_000);
+
+afterAll(async () => {
+  if (vercelProcess && !vercelProcess.killed) {
+    vercelProcess.kill('SIGTERM');
+    await Promise.race([
+      once(vercelProcess, 'exit'),
+      new Promise((resolve) => {
+        setTimeout(resolve, 5000);
+      }),
+    ]);
+  }
+
+  if (oauthServiceStub) {
+    await new Promise((resolve) => {
+      oauthServiceStub.close(resolve);
+    });
+  }
+});
+
+describe('vercel runtime', () => {
+  it('should serve the comment API through vercel dev', async () => {
+    const response = await waitForVercel();
+    const body = await response.json();
+
+    expect(body.errno).toBe(0);
+    expect(body.data).toMatchObject({
+      page: 1,
+      pageSize: 10,
+      count: 0,
+      data: [],
+    });
+  }, 70_000);
+
+  it('should publish and fetch a comment through vercel dev', async () => {
+    await waitForVercel();
+
+    const comment = {
+      nick: 'Vercel Tester',
+      mail: 'vercel-tester@example.com',
+      link: 'https://example.com',
+      comment: 'Hello from Vercel runtime',
+      url: testPath,
+      ua: 'vitest-vercel-runtime',
+    };
+
+    const postResponse = await fetch(`${getVercelUrl()}/api/comment`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(comment),
+    });
+    const postBody = await postResponse.json();
+
+    expect(postResponse.ok).toBe(true);
+    expect(postBody.errno).toBe(0);
+    expect(postBody.data).toMatchObject({
+      nick: comment.nick,
+      link: comment.link,
+      objectId: 'vercel-comment-1',
+    });
+
+    const getResponse = await fetch(
+      `${getVercelUrl()}/api/comment?path=${encodeURIComponent(testPath)}`,
+    );
+    const getBody = await getResponse.json();
+
+    expect(getResponse.ok).toBe(true);
+    expect(getBody.errno).toBe(0);
+    expect(getBody.data).toMatchObject({
+      page: 1,
+      pageSize: 10,
+      count: 1,
+    });
+    expect(getBody.data.data).toHaveLength(1);
+    expect(getBody.data.data[0]).toMatchObject({
+      nick: comment.nick,
+      link: comment.link,
+      objectId: 'vercel-comment-1',
+    });
+    expect(getBody.data.data[0].comment).toContain(comment.comment);
+  }, 70_000);
+});


### PR DESCRIPTION
### Motivation
- Add an automated integration test to validate the server behavior when run inside the Vercel serverless runtime and catch regressions specific to that environment.

### Description
- Add a Vercel test fixture at `packages/server/__tests__/fixtures/vercel/index.cjs` implementing a file-backed `Comment` model and minimal `Users` model for local testing.
- Add `packages/server/__tests__/fixtures/vercel/vercel.json` to configure the `@vercel/node` runtime and route all requests to `index.cjs`.
- Add `packages/server/__tests__/vercel.spec.js` which spawns `vercel dev`, stubs the OAuth service, exercises the comment API (POST and GET), and asserts expected responses and persisted data.

### Testing
- Ran the new integration test with `vitest` targeting `packages/server/__tests__/vercel.spec.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3236a5638083268297f0e56ee43ad4)