### PR TITLE
Disable framework X-Powered-By header, expose Waline version header, and add tests

### DIFF
--- a/packages/server/__tests__/token.spec.js
+++ b/packages/server/__tests__/token.spec.js
@@ -17,6 +17,7 @@ globalThis.fetch = async (url, options) => {
 };
 
 const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
 const main = require('../index.js');
 
 // Use a custom model stub so no real database connection is needed
@@ -57,7 +58,7 @@ afterAll(async () => {
   await new Promise((resolve) => server.close(resolve));
 });
 
-const apiRequest = (method, path, body) => {
+const request = (method, path, body) => {
   const url = `http://localhost:${port}${path}`;
   const options = {
     method,
@@ -66,8 +67,22 @@ const apiRequest = (method, path, body) => {
   if (method !== 'GET' && body) {
     options.body = JSON.stringify(body);
   }
-  return fetch(url, options).then((r) => r.json());
+  return fetch(url, options);
 };
+
+const apiRequest = (method, path, body) =>
+  request(method, path, body).then((r) => r.json());
+
+const apiResponse = (method, path, body) => request(method, path, body);
+
+describe('security headers', () => {
+  it('should not expose the framework header while keeping the Waline version header', async () => {
+    const response = await apiResponse('GET', '/api/token');
+
+    expect(response.headers.get('x-powered-by')).toBeNull();
+    expect(response.headers.get('x-waline-version')).toBe(pkg.version);
+  });
+});
 
 describe('gET /api/token', () => {
   it('should return empty user info when not authenticated', async () => {

--- a/packages/server/src/config/middleware.js
+++ b/packages/server/src/config/middleware.js
@@ -23,6 +23,7 @@ module.exports = [
     handle: 'meta',
     options: {
       logRequest: isDev,
+      sendPowerBy: false,
       sendResponseTime: isDev,
       requestTimeoutCallback: isTcb || isAliyunFC || isNetlify ? false : () => {},
     },


### PR DESCRIPTION
### Motivation

- Prevent leaking the underlying framework via the `X-Powered-By` header while still advertising the Waline package version.  
- Strengthen tests to assert HTTP security headers and make request helpers clearer for raw response vs parsed JSON usage.

### Description

- Set `sendPowerBy: false` in the `meta` middleware options to stop emitting the framework `X-Powered-By` header.  
- Require `package.json` in tests and assert `x-waline-version` matches `pkg.version` and that `x-powered-by` is not present.  
- Refactor test helpers by introducing `request` (returns raw `fetch` response), `apiRequest` (returns parsed JSON), and `apiResponse` (returns raw response) and update `token.spec.js` accordingly.  
- Add a new `security headers` test suite in `packages/server/__tests__/token.spec.js` to validate header behavior.

### Testing

- Ran unit tests in `packages/server/__tests__/token.spec.js` via the test runner (`vitest`) which executed the updated header assertions.  
- All automated tests related to the change completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cd46b4f648326b4b570caa76d5f76)