### PR TITLE
Refactor comment pagination and add explicit `order` support to SQL storages

### DIFF
--- a/packages/server/src/controller/comment.js
+++ b/packages/server/src/controller/comment.js
@@ -423,54 +423,27 @@ module.exports = class CommentController extends BaseRest {
       }
     }
 
-    /**
-     * Most of case we have just little comments while if we want get rootComments, rootCount,
-     * childComments with pagination we have to query three times from storage service That's so
-     * expensive for user, especially in the serverless. so we have a comments length check If you
-     * have less than 1000 comments, then we'll get all comments one time then we'll compute
-     * rootComment, rootCount, childComments in program to reduce http request query
-     *
-     * Why we have limit and the limit is 1000? Many serverless storages have fetch data limit, for
-     * example LeanCloud is 100, and CloudBase is 1000 If we have much comments, We should use more
-     * request to fetch all comments If we have 3000 comments, We have to use 30 http request to
-     * fetch comments, things go athwart. And Serverless Service like vercel have execute time limit
-     * if we have more http requests in a serverless function, it may timeout easily. so we use
-     * limit to avoid it.
-     */
-    if (totalCount < 1000) {
-      comments = await this.modelInstance.select(where, selectOptions);
-      rootCount = comments.filter(({ rid }) => !rid).length;
-      rootComments = [
-        ...comments.filter(({ rid, sticky }) => !rid && sticky),
-        ...comments.filter(({ rid, sticky }) => !rid && !sticky),
-      ].slice(pageOffset, pageOffset + pageSize);
-      const rootIds = {};
+    const rootWhere = { ...where, rid: undefined };
+    const sortField = selectOptions.desc ?? 'insertedAt';
+    const sortOrder = selectOptions.desc ? 'DESC' : 'ASC';
 
-      rootComments.forEach(({ objectId }) => {
-        rootIds[objectId] = true;
-      });
-      comments = comments.filter((cmt) => rootIds[cmt.objectId] || rootIds[cmt.rid]);
-    } else {
-      comments = await this.modelInstance.select(
-        { ...where, rid: undefined },
-        { ...selectOptions },
-      );
-      rootCount = comments.length;
-      rootComments = [
-        ...comments.filter(({ rid, sticky }) => !rid && sticky),
-        ...comments.filter(({ rid, sticky }) => !rid && !sticky),
-      ].slice(pageOffset, pageOffset + pageSize);
+    rootCount = await this.modelInstance.count(rootWhere);
+    rootComments = await this.modelInstance.select(rootWhere, {
+      ...selectOptions,
+      order: { sticky: 'DESC', [sortField]: sortOrder },
+      limit: pageSize,
+      offset: pageOffset,
+    });
 
-      const children = await this.modelInstance.select(
-        {
-          ...where,
-          rid: ['IN', rootComments.map(({ objectId }) => objectId)],
-        },
-        selectOptions,
-      );
+    const children = await this.modelInstance.select(
+      {
+        ...where,
+        rid: ['IN', rootComments.map(({ objectId }) => objectId)],
+      },
+      selectOptions,
+    );
 
-      comments = [...rootComments, ...children];
-    }
+    comments = [...rootComments, ...children];
 
     const userModel = this.getModel('Users');
     const user_ids = [...new Set(comments.map(({ user_id }) => user_id).filter(Boolean))];

--- a/packages/server/src/service/storage/mysql.js
+++ b/packages/server/src/service/storage/mysql.js
@@ -40,11 +40,13 @@ module.exports = class extends Base {
     return where;
   }
 
-  async select(where, { desc, limit, offset, field } = {}) {
+  async select(where, { desc, field, limit, offset, order } = {}) {
     const instance = this.model(this.tableName);
 
     instance.where(this.parseWhere(where));
-    if (desc) {
+    if (order) {
+      instance.order(order);
+    } else if (desc) {
       instance.order({ [desc]: 'DESC' });
     }
 

--- a/packages/server/src/service/storage/postgresql.js
+++ b/packages/server/src/service/storage/postgresql.js
@@ -33,6 +33,12 @@ module.exports = class extends MySQL {
       options.desc = options.desc.toLowerCase();
     }
 
+    if (options?.order) {
+      options.order = Object.fromEntries(
+        Object.entries(options.order).map(([field, order]) => [field.toLowerCase(), order]),
+      );
+    }
+
     if (Array.isArray(options.field)) {
       options.field = options.field.map((field) => field.toLowerCase());
     }


### PR DESCRIPTION
### Motivation
- Reduce expensive multi-query logic for comment listing and support explicit sort ordering across storages.
- Ensure stable ordering that always respects `sticky` first, then the requested sort field and direction.
- Unify ordering parameter handling between MySQL and PostgreSQL storage adapters.

### Description
- Refactored comment controller to compute `rootCount` with `this.modelInstance.count(rootWhere)` and fetch paginated root comments using `select` with `order`, `limit`, and `offset` instead of branching on total size and fetching all comments in-memory.
- Root comments are now ordered by `sticky` descending and by the requested sort field/direction via `order: { sticky: 'DESC', [sortField]: sortOrder }`, and child comments are fetched with `rid: ['IN', rootIds]` as before.
- Extended MySQL storage `select` signature to accept an `order` option and call `instance.order(order)` while keeping backward compatibility with the legacy `desc` option, and preserved `field` and pagination behavior.
- Normalized `order` keys in the PostgreSQL storage adapter by lowercasing fields in `options.order` before delegating to the parent implementation.

### Testing
- Ran the server test suite for the `packages/server` package (unit and storage adapter tests) with `npm test`, and all tests completed successfully.
- Verified comment listing behavior by exercising the controller endpoints in automated integration tests, and the responses matched expected pagination and ordering results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ce89284188326a831e31aeeeee78e)


fix https://github.com/walinejs/waline/issues/3678 when pr merged