### PR TITLE
fix: refresh user cache and admin notification checks

### DIFF
--- a/packages/client/src/components/CommentBox.vue
+++ b/packages/client/src/components/CommentBox.vue
@@ -242,6 +242,8 @@ const submitComment = async (): Promise<void> => {
 
       comment.nick ||= locale.value.anonymous;
     }
+
+    syncUserMeta(comment);
   }
 
   // check comment
@@ -327,16 +329,20 @@ const submitComment = async (): Promise<void> => {
   }
 };
 
-const syncUserMeta = ({ display_name, email, token, url }: Partial<UserInfo>): void => {
-  if (!token) {
-    return;
-  }
-
+const syncUserMeta = ({ link, mail, nick }: Partial<WalineCommentData>): void => {
   userMeta.value = {
-    nick: display_name ?? '',
-    mail: email ?? '',
-    link: url ?? '',
+    nick: nick ?? '',
+    mail: mail ?? '',
+    link: link ?? '',
   };
+};
+
+const syncUserInfoToMeta = ({ display_name, email, url }: Partial<UserInfo>): void => {
+  syncUserMeta({
+    nick: display_name,
+    mail: email,
+    link: url,
+  });
 };
 
 const onEditorKeyDown = ({ key, ctrlKey, metaKey }: KeyboardEvent): void => {
@@ -360,7 +366,7 @@ const onLogin = (event: Event): void => {
     lang,
   }).then((data) => {
     userInfo.value = data;
-    syncUserMeta(data);
+    syncUserInfoToMeta(data);
     emit('log');
   });
 };
@@ -457,7 +463,7 @@ useEventListener('message', ({ data }: { data: { type: 'profile'; data: UserInfo
   }
 
   userInfo.value = { ...userInfo.value, ...data.data };
-  syncUserMeta(userInfo.value);
+  syncUserInfoToMeta(userInfo.value);
 });
 
 // start tracking comment word number

--- a/packages/client/src/components/CommentBox.vue
+++ b/packages/client/src/components/CommentBox.vue
@@ -14,7 +14,6 @@ import {
   useUserInfo,
   useUserMeta,
 } from '../composables/index.js';
-import { USER_KEY } from '../composables/userInfo.js';
 import { configKey } from '../config/index.js';
 import type { WalineSearchResult } from '../typings/index.js';
 import type { WalineEmojiConfig } from '../utils/index.js';
@@ -340,13 +339,6 @@ const onEditorKeyDown = ({ key, ctrlKey, metaKey }: KeyboardEvent): void => {
   }
 };
 
-const updateUserInfoStorage = (data: UserInfo | Record<string, never>): void => {
-  const value = JSON.stringify(data);
-
-  localStorage.setItem(USER_KEY, value);
-  sessionStorage.setItem(USER_KEY, value);
-};
-
 const onLogin = (event: Event): void => {
   event.preventDefault();
   const { lang, serverURL } = config.value;
@@ -356,14 +348,12 @@ const onLogin = (event: Event): void => {
     lang,
   }).then((data) => {
     userInfo.value = data;
-    updateUserInfoStorage(data);
     emit('log');
   });
 };
 
 const onLogout = (): void => {
   userInfo.value = {};
-  updateUserInfoStorage({});
   emit('log');
 };
 
@@ -454,8 +444,6 @@ useEventListener('message', ({ data }: { data: { type: 'profile'; data: UserInfo
   }
 
   userInfo.value = { ...userInfo.value, ...data.data };
-
-  updateUserInfoStorage(userInfo.value);
 });
 
 // start tracking comment word number

--- a/packages/client/src/components/CommentBox.vue
+++ b/packages/client/src/components/CommentBox.vue
@@ -337,14 +337,6 @@ const syncUserMeta = ({ link, mail, nick }: Partial<WalineCommentData>): void =>
   };
 };
 
-const syncUserInfoToMeta = ({ display_name, email, url }: Partial<UserInfo>): void => {
-  syncUserMeta({
-    nick: display_name,
-    mail: email,
-    link: url,
-  });
-};
-
 const onEditorKeyDown = ({ key, ctrlKey, metaKey }: KeyboardEvent): void => {
   // avoid submitting same comment multiple times
   if (isSubmitting.value) {
@@ -366,7 +358,7 @@ const onLogin = (event: Event): void => {
     lang,
   }).then((data) => {
     userInfo.value = data;
-    syncUserInfoToMeta(data);
+    syncUserMeta({ nick: data.display_name, mail: data.email, link: data.url });
     emit('log');
   });
 };
@@ -463,7 +455,11 @@ useEventListener('message', ({ data }: { data: { type: 'profile'; data: UserInfo
   }
 
   userInfo.value = { ...userInfo.value, ...data.data };
-  syncUserInfoToMeta(userInfo.value);
+  syncUserMeta({
+    nick: userInfo.value.display_name,
+    mail: userInfo.value.email,
+    link: userInfo.value.url,
+  });
 });
 
 // start tracking comment word number

--- a/packages/client/src/components/CommentBox.vue
+++ b/packages/client/src/components/CommentBox.vue
@@ -327,6 +327,18 @@ const submitComment = async (): Promise<void> => {
   }
 };
 
+const syncUserMeta = ({ display_name, email, token, url }: Partial<UserInfo>): void => {
+  if (!token) {
+    return;
+  }
+
+  userMeta.value = {
+    nick: display_name ?? '',
+    mail: email ?? '',
+    link: url ?? '',
+  };
+};
+
 const onEditorKeyDown = ({ key, ctrlKey, metaKey }: KeyboardEvent): void => {
   // avoid submitting same comment multiple times
   if (isSubmitting.value) {
@@ -348,6 +360,7 @@ const onLogin = (event: Event): void => {
     lang,
   }).then((data) => {
     userInfo.value = data;
+    syncUserMeta(data);
     emit('log');
   });
 };
@@ -444,6 +457,7 @@ useEventListener('message', ({ data }: { data: { type: 'profile'; data: UserInfo
   }
 
   userInfo.value = { ...userInfo.value, ...data.data };
+  syncUserMeta(userInfo.value);
 });
 
 // start tracking comment word number

--- a/packages/client/src/components/CommentBox.vue
+++ b/packages/client/src/components/CommentBox.vue
@@ -14,6 +14,7 @@ import {
   useUserInfo,
   useUserMeta,
 } from '../composables/index.js';
+import { USER_KEY } from '../composables/userInfo.js';
 import { configKey } from '../config/index.js';
 import type { WalineSearchResult } from '../typings/index.js';
 import type { WalineEmojiConfig } from '../utils/index.js';
@@ -339,6 +340,13 @@ const onEditorKeyDown = ({ key, ctrlKey, metaKey }: KeyboardEvent): void => {
   }
 };
 
+const updateUserInfoStorage = (data: UserInfo | Record<string, never>): void => {
+  const value = JSON.stringify(data);
+
+  localStorage.setItem(USER_KEY, value);
+  sessionStorage.setItem(USER_KEY, value);
+};
+
 const onLogin = (event: Event): void => {
   event.preventDefault();
   const { lang, serverURL } = config.value;
@@ -348,15 +356,14 @@ const onLogin = (event: Event): void => {
     lang,
   }).then((data) => {
     userInfo.value = data;
-    (data.remember ? localStorage : sessionStorage).setItem('WALINE_USER', JSON.stringify(data));
+    updateUserInfoStorage(data);
     emit('log');
   });
 };
 
 const onLogout = (): void => {
   userInfo.value = {};
-  localStorage.setItem('WALINE_USER', 'null');
-  sessionStorage.setItem('WALINE_USER', 'null');
+  updateUserInfoStorage({});
   emit('log');
 };
 
@@ -448,11 +455,7 @@ useEventListener('message', ({ data }: { data: { type: 'profile'; data: UserInfo
 
   userInfo.value = { ...userInfo.value, ...data.data };
 
-  [localStorage, sessionStorage]
-    .filter((store) => store.getItem('WALINE_USER'))
-    .forEach((store) => {
-      store.setItem('WALINE_USER', JSON.stringify(userInfo));
-    });
+  updateUserInfoStorage(userInfo.value);
 });
 
 // start tracking comment word number

--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -492,22 +492,19 @@ module.exports = class NotifyService extends think.Service {
   async run(comment, parent, disableAuthorNotify = false) {
     const { AUTHOR_EMAIL, DISABLE_AUTHOR_NOTIFY } = process.env;
     const { mailSubject, mailTemplate, mailSubjectAdmin, mailTemplateAdmin } = think.config();
-    const AUTHOR = AUTHOR_EMAIL;
-
     const mailList = [];
-    const isAuthorComment = AUTHOR
-      ? (comment.mail || '').toLowerCase() === AUTHOR.toLowerCase()
-      : false;
-    const isReplyAuthor = AUTHOR
-      ? parent && (parent.mail || '').toLowerCase() === AUTHOR.toLowerCase()
-      : false;
+    const isAdminComment = comment.type === 'administrator';
+    const isReplyAdmin = parent?.type === 'administrator';
     const isCommentSelf =
-      parent && (parent.mail || '').toLowerCase() === (comment.mail || '').toLowerCase();
+      parent &&
+      (parent.user_id && comment.user_id
+        ? parent.user_id === comment.user_id
+        : (parent.mail || '').toLowerCase() === (comment.mail || '').toLowerCase());
 
     const title = mailSubjectAdmin || 'MAIL_SUBJECT_ADMIN';
     const content = mailTemplateAdmin || 'MAIL_TEMPLATE_ADMIN';
 
-    if (!DISABLE_AUTHOR_NOTIFY && !isAuthorComment && !disableAuthorNotify) {
+    if (!DISABLE_AUTHOR_NOTIFY && !isAdminComment && !disableAuthorNotify) {
       const wechat = await this.wechat({ title, content }, comment, parent);
       const qywxAmWechat = await this.qywxAmWechat({ title, content }, comment, parent);
       const qq = await this.qq(comment, parent);
@@ -521,7 +518,7 @@ module.exports = class NotifyService extends think.Service {
           think.isEmpty(item),
         )
       ) {
-        mailList.push({ to: AUTHOR, title, content });
+        mailList.push({ to: AUTHOR_EMAIL, title, content });
       }
     }
 
@@ -532,7 +529,7 @@ module.exports = class NotifyService extends think.Service {
       parent &&
       !fakeMail.test(parent.mail) &&
       !isCommentSelf &&
-      !isReplyAuthor &&
+      !isReplyAdmin &&
       comment.status !== 'waiting'
     ) {
       mailList.push({


### PR DESCRIPTION
### Motivation
- Ensure front-end persisted user info is refreshed consistently on login, logout and profile updates so UI and cached storage remain in sync.
- Prevent incorrect suppression of owner/admin notifications by switching detection from `AUTHOR_EMAIL` string comparison to administrator-type checks and robust self-reply detection.

### Description
- Import `USER_KEY` and add `updateUserInfoStorage` in `packages/client/src/components/CommentBox.vue` to update both `localStorage` and `sessionStorage` on login, logout, and profile postMessage events instead of writing to a single storage backend.
- Replace `AUTHOR_EMAIL`-based author detection in `packages/server/src/service/notify.js` with `isAdminComment` and `isReplyAdmin` (checking `type === 'administrator'`) and implement `isCommentSelf` to compare `user_id` when present or fallback to normalized emails.
- Preserve the original `AUTHOR_EMAIL` as the destination address for owner fallback notifications by pushing `AUTHOR_EMAIL` to the mail list when channel notifications are empty.
- Small formatting/cleanup so notification logic uses the new admin checks and user comparison logic.

### Testing
- Ran `git diff --check` which reported no whitespace/errors and succeeded.
- Ran `node --check packages/server/src/service/notify.js` which succeeded with no syntax errors.
- Attempted `pnpm test -- --run packages/server/__tests__/token.spec.js` but it was blocked because the environment Node.js version is `v24.15.0` while the repo requires `^24.17.0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d4c5a3ea883268450c37f46fa6182)