### PR TITLE
test: add Vercel client preview fixture

### DIFF
--- a/packages/server/__tests__/fixtures/vercel/index.html
+++ b/packages/server/__tests__/fixtures/vercel/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Waline Vercel Preview</title>
+  </head>
+  <body>
+    <main>
+      <h1>Waline Vercel Preview</h1>
+      <p>This page mounts the workspace @waline/client package against the preview API.</p>
+      <div id="waline"></div>
+    </main>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/server/__tests__/fixtures/vercel/package.json
+++ b/packages/server/__tests__/fixtures/vercel/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "cd ../../../.. && pnpm --dir packages/api build && pnpm exec vite build packages/server/__tests__/fixtures/vercel"
+    "build": "cd ../../../../.. && pnpm --dir packages/api build && pnpm exec vite build packages/server/__tests__/fixtures/vercel"
   }
 }

--- a/packages/server/__tests__/fixtures/vercel/package.json
+++ b/packages/server/__tests__/fixtures/vercel/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "cd ../../../.. && pnpm --dir packages/api build && pnpm exec vite build packages/server/__tests__/fixtures/vercel"
+  }
+}

--- a/packages/server/__tests__/fixtures/vercel/src/main.ts
+++ b/packages/server/__tests__/fixtures/vercel/src/main.ts
@@ -1,0 +1,8 @@
+import { init } from '../../../../../client/src/entries/init.ts';
+import '../../../../../client/src/styles/index.scss';
+
+init({
+  el: '#waline',
+  serverURL: window.location.origin,
+  path: window.location.pathname,
+});

--- a/packages/server/__tests__/fixtures/vercel/vercel.json
+++ b/packages/server/__tests__/fixtures/vercel/vercel.json
@@ -38,5 +38,5 @@
       "destination": "index.cjs"
     }
   ],
-  "installCommand": "cd ../../../.. && pnpm install --frozen-lockfile"
+  "installCommand": "cd ../../../../.. && pnpm install --frozen-lockfile"
 }

--- a/packages/server/__tests__/fixtures/vercel/vercel.json
+++ b/packages/server/__tests__/fixtures/vercel/vercel.json
@@ -5,6 +5,13 @@
   },
   "builds": [
     {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    },
+    {
       "src": "index.cjs",
       "use": "@vercel/node",
       "config": {
@@ -19,8 +26,17 @@
   ],
   "rewrites": [
     {
+      "source": "/api/(.*)",
+      "destination": "index.cjs"
+    },
+    {
+      "source": "/",
+      "destination": "/index.html"
+    },
+    {
       "source": "/(.*)",
       "destination": "index.cjs"
     }
-  ]
+  ],
+  "installCommand": "cd ../../../.. && pnpm install --frozen-lockfile"
 }

--- a/packages/server/__tests__/vercel.spec.js
+++ b/packages/server/__tests__/vercel.spec.js
@@ -113,6 +113,17 @@ afterAll(async () => {
 });
 
 describe('vercel runtime', () => {
+  it('should serve the client preview page through vercel dev', async () => {
+    await waitForVercel();
+
+    const response = await fetch(getVercelUrl());
+    const body = await response.text();
+
+    expect(response.ok).toBe(true);
+    expect(body).toContain('Waline Vercel Preview');
+    expect(body).toContain('/assets/');
+  }, 70_000);
+
   it('should serve the comment API through vercel dev', async () => {
     const response = await waitForVercel();
     const body = await response.json();


### PR DESCRIPTION
### Motivation
- Provide a static preview page for Vercel PR previews that mounts the workspace `@waline/client` against the preview API so front-end changes can be previewed alongside the server runtime. 
- Ensure the Vercel fixture can build workspace dependencies (notably `@waline/api`) and produce a Vite static build via `@vercel/static-build`, while keeping the `/api/*` routes handled by the existing serverless function.

### Description
- Added a static preview page at `packages/server/__tests__/fixtures/vercel/index.html` that loads a Vite entry script and provides a `#waline` mount point. 
- Added a Vite entry `packages/server/__tests__/fixtures/vercel/src/main.ts` that imports `packages/client/src/entries/init.ts` and `packages/client/src/styles/index.scss` and initializes the client against `window.location`. 
- Added a fixture `package.json` with a `build` script that first builds `@waline/api` and then runs `vite build` for the fixture. 
- Updated `packages/server/__tests__/fixtures/vercel/vercel.json` to add an `@vercel/static-build` entry, an `installCommand` to install workspace deps from the repo root, and rewrites to route `/` to the generated `index.html` while preserving `/api/(.*)` to `index.cjs`. 
- Added a runtime test in `packages/server/__tests__/vercel.spec.js` that asserts the root preview page is served and contains the generated asset references. 

### Testing
- Ran a sanity parse check on the new fixture JSON and `package.json` with `node -e "JSON.parse(require('fs').readFileSync('packages/server/__tests__/fixtures/vercel/vercel.json','utf8')); JSON.parse(require('fs').readFileSync('packages/server/__tests__/fixtures/vercel/package.json','utf8')); console.log('ok')"`, which printed `ok`.
- Attempted to run the fixture build and `vitest` (`pnpm --dir packages/server/__tests__/fixtures/vercel build` and `pnpm vitest packages/server/__tests__/vercel.spec.js --run`) but automated runs were blocked by the environment Node.js version (`v24.15.0`) not meeting the repo `devEngines` requirement of `^24.17.0`.
- Changes committed locally with the message `test: add vercel client preview fixture`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a436a724bdc8326a63dafb70127268f)