### PR TITLE
fix(server): replace vulnerable CloudBase SDK

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,6 @@
     "dev": "node development.js 9090"
   },
   "dependencies": {
-    "@cloudbase/node-sdk": "^3.18.3",
     "@koa/cors": "^5.0.0",
     "@mathjax/mathjax-tex-font": "^4.1.2",
     "@mathjax/src": "^4.1.2",
@@ -46,6 +45,7 @@
     "prismjs": "^1.30.0",
     "rss": "^1.2.2",
     "speakeasy": "^2.0.0",
+    "tencentcloud-sdk-nodejs": "^4.1.194",
     "think-helper": "^1.1.5",
     "think-logger3": "^1.4.0",
     "think-model": "^1.5.4",

--- a/packages/server/src/service/storage/cloudbase.js
+++ b/packages/server/src/service/storage/cloudbase.js
@@ -1,41 +1,76 @@
-const cloudbase = require('@cloudbase/node-sdk');
+const tencentcloud = require('tencentcloud-sdk-nodejs');
+
+const TcbClient = tencentcloud.tcb.v20180608.Client;
+const { Credential } = tencentcloud.common;
+const { ClientProfile, HttpProfile } = tencentcloud.common.profile;
 
 const Base = require('./base.js');
 
-const { TCB_ENV, TCB_ID, TCB_KEY } = process.env;
-const app = cloudbase.init({
-  env: TCB_ENV,
-  secretId: TCB_ID,
-  secretKey: TCB_KEY,
+const { TCB_ENV, TCB_ID, TCB_KEY, TCB_REGION = 'ap-shanghai' } = process.env;
+
+const httpProfile = new HttpProfile();
+
+httpProfile.endpoint = 'tcb.tencentcloudapi.com';
+
+const clientProfile = new ClientProfile();
+
+clientProfile.httpProfile = httpProfile;
+
+const client = new TcbClient(new Credential(TCB_ID, TCB_KEY), TCB_REGION, clientProfile);
+const collections = {};
+
+const runCommand = async (tableName, commandType, command) => {
+  const { Data } = await client.RunCommands({
+    EnvId: TCB_ENV,
+    MgoCommands: [
+      {
+        TableName: tableName,
+        CommandType: commandType,
+        Command: JSON.stringify(command),
+      },
+    ],
+  });
+  const [result = '[]'] = Data ?? [];
+
+  return JSON.parse(result);
+};
+
+const parseDoc = (doc) => (typeof doc === 'string' ? JSON.parse(doc) : doc);
+
+const normalizeDoc = ({ _id, ...doc }) => ({
+  ...doc,
+  objectId: _id?.toString(),
 });
 
-const db = app.database();
-const _ = db.command;
-const $ = db.command.aggregate;
-const collections = {};
+const eq = (value) => ({ $eq: value });
+const neq = (value) => ({ $ne: value });
+const gt = (value) => ({ $gt: value });
+const includes = (value) => ({ $in: value });
+const excludes = (value) => ({ $nin: value });
+const sum = (value) => ({ $sum: value });
+const and = (...filters) => ({ $and: filters });
+const or = (...filters) => ({ $or: filters });
+
+const _ = { eq, neq, gt, in: includes, nin: excludes, and, or };
+const $ = { sum };
 
 module.exports = class extends Base {
   async collection(tableName) {
-    if (collections[tableName]) {
-      return db.collection(tableName);
-    }
+    if (!collections[tableName]) {
+      try {
+        await runCommand(tableName, 'QUERY', { count: tableName });
+      } catch (err) {
+        if (err.code !== 'ResourceNotFound.Table') {
+          throw err;
+        }
 
-    try {
-      const instance = db.collection(tableName);
-
-      await instance.count();
-      collections[tableName] = true;
-
-      return db.collection(tableName);
-    } catch (err) {
-      if (err.code === 'DATABASE_COLLECTION_NOT_EXIST') {
-        await db.createCollection(tableName);
-        collections[tableName] = true;
-
-        return db.collection(tableName);
+        await runCommand(tableName, 'COMMAND', { create: tableName });
       }
-      throw err;
+
+      collections[tableName] = true;
     }
+
+    return tableName;
   }
 
   parseWhere(where) {
@@ -78,11 +113,11 @@ module.exports = class extends Base {
             let reg;
 
             if (first === '%' && last === '%') {
-              reg = new RegExp(likePattern.slice(1, -1), 'u');
+              reg = { $regex: likePattern.slice(1, -1) };
             } else if (first === '%') {
-              reg = new RegExp(`${likePattern.slice(1)}$`, 'u');
+              reg = { $regex: `${likePattern.slice(1)}$` };
             } else if (last === '%') {
-              reg = new RegExp(`^${likePattern.slice(0, -1)}`, 'u');
+              reg = { $regex: `^${likePattern.slice(0, -1)}` };
             }
 
             filter[parseKey(k)] = reg;
@@ -103,14 +138,8 @@ module.exports = class extends Base {
       }
     }
 
-    return filter;
-  }
-
-  where(instance, where, method = 'where') {
-    const filter = this.parseWhere(where);
-
     if (!where._complex) {
-      return instance[method](filter);
+      return filter;
     }
 
     const filters = [];
@@ -126,38 +155,33 @@ module.exports = class extends Base {
       });
     }
 
-    return instance[method](_[where._complex._logic](...filters));
+    return _[where._complex._logic](...filters);
   }
 
   async _select(where, { desc, limit, offset, field } = {}) {
-    let instance = await this.collection(this.tableName);
+    const tableName = await this.collection(this.tableName);
+    const command = { find: tableName, filter: this.parseWhere(where) };
 
-    instance = this.where(instance, where);
     if (desc) {
-      instance = instance.orderBy(desc, 'desc');
+      command.sort = { [desc]: -1 };
     }
 
     if (limit) {
-      instance = instance.limit(limit);
+      command.limit = limit;
     }
 
     if (offset) {
-      instance = instance.skip(offset);
+      command.skip = offset;
     }
 
     if (field) {
-      const filedObj = {};
-
-      field.forEach((f) => (filedObj[f] = true));
-      instance = instance.field(filedObj);
+      command.projection = {};
+      field.forEach((f) => (command.projection[f] = 1));
     }
 
-    const { data } = await instance.get();
+    const data = await runCommand(tableName, 'QUERY', command);
 
-    return data.map(({ _id, ...cmt }) => ({
-      ...cmt,
-      objectId: _id.toString(),
-    }));
+    return data.map((item) => normalizeDoc(parseDoc(item)));
   }
 
   async select(where, options = {}) {
@@ -176,13 +200,16 @@ module.exports = class extends Base {
   }
 
   async count(where = {}, { group } = {}) {
-    let instance = await this.collection(this.tableName);
+    const tableName = await this.collection(this.tableName);
+    const filter = this.parseWhere(where);
 
     if (!group) {
-      instance = this.where(instance, where);
-      const { total } = await instance.count();
+      const { n = 0 } = await runCommand(tableName, 'QUERY', {
+        count: tableName,
+        query: filter,
+      });
 
-      return total;
+      return n;
     }
 
     // oxlint-disable-next-line no-underscore-dangle
@@ -191,12 +218,17 @@ module.exports = class extends Base {
     group.forEach((f) => {
       _id[f] = `$${f}`;
     });
-    instance = instance.aggregate();
-    this.where(instance, where, 'match');
-    instance = instance.group({ _id, count: $.sum(1) });
-    const { data } = await instance.end();
 
-    return data.map(({ _id, count }) => ({ ..._id, count }));
+    const data = await runCommand(tableName, 'QUERY', {
+      aggregate: tableName,
+      pipeline: [{ $match: filter }, { $group: { _id, count: $.sum(1) } }],
+      cursor: {},
+    });
+
+    return (data.cursor?.firstBatch ?? data).map(({ _id, count }) => ({
+      ..._id,
+      count,
+    }));
   }
 
   async add(data) {
@@ -206,23 +238,34 @@ module.exports = class extends Base {
       delete data.objectId;
     }
 
-    const instance = await this.collection(this.tableName);
-    const { id } = await instance.add(data);
+    const tableName = await this.collection(this.tableName);
+    const result = await runCommand(tableName, 'INSERT', {
+      insert: tableName,
+      documents: [data],
+    });
+    const insertedId = result.insertedId ?? result.insertedIds?.[0];
 
-    return { ...data, objectId: id };
+    return { ...data, objectId: insertedId ?? data._id };
   }
 
   async update(data, where) {
-    const instance = await this.collection(this.tableName);
-    const { data: list } = await this.where(instance, where).get();
+    const tableName = await this.collection(this.tableName);
+    const list = await this._select(where);
 
     return Promise.all(
       list.map(async (item) => {
         const updateData = typeof data === 'function' ? data(item) : data;
-        const instance = await this.collection(this.tableName);
 
-        // oxlint-disable-next-line no-underscore-dangle
-        await instance.doc(item._id).update(updateData);
+        await runCommand(tableName, 'UPDATE', {
+          update: tableName,
+          updates: [
+            {
+              q: { _id: item.objectId },
+              u: { $set: updateData },
+              multi: false,
+            },
+          ],
+        });
 
         return { ...item, ...updateData };
       }),
@@ -230,8 +273,11 @@ module.exports = class extends Base {
   }
 
   async delete(where) {
-    const instance = await this.collection(this.tableName);
+    const tableName = await this.collection(this.tableName);
 
-    return this.where(instance, where).remove();
+    return runCommand(tableName, 'DELETE', {
+      delete: tableName,
+      deletes: [{ q: this.parseWhere(where), limit: 0 }],
+    });
   }
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,8 +204,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@cloudbase/database>lodash.unset': ^4.18.0
-  '@cloudbase/node-sdk>axios': ^0.33.0
   '@next-theme/utils>js-yaml': ^5.0.0
   '@waline/api': workspace:*
   '@waline/client': workspace:*
@@ -304,7 +302,7 @@ importers:
         version: 0.3.1(synckit@0.11.12)
       vercel:
         specifier: 54.18.6
-        version: 54.18.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+        version: 54.18.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(supports-color@5.5.0)
       vite:
         specifier: 8.1.0
         version: 8.1.0(@types/node@26.0.1)(esbuild@0.28.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
@@ -473,9 +471,6 @@ importers:
 
   packages/server:
     dependencies:
-      '@cloudbase/node-sdk':
-        specifier: ^3.18.3
-        version: 3.18.3(supports-color@5.5.0)
       '@koa/cors':
         specifier: ^5.0.0
         version: 5.0.0
@@ -548,6 +543,9 @@ importers:
       speakeasy:
         specifier: ^2.0.0
         version: 2.0.0
+      tencentcloud-sdk-nodejs:
+        specifier: ^4.1.194
+        version: 4.1.260
       think-helper:
         specifier: ^1.1.5
         version: 1.1.5
@@ -1217,37 +1215,6 @@ packages:
 
   '@cacheable/utils@2.4.1':
     resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
-
-  '@cloudbase/adapter-interface@0.7.1':
-    resolution: {integrity: sha512-BjHTAvIMSLxbp26SeT6qLiSSBygz3kAVno/PMwwBwjgzVkVUvuZGVcvf1mhHxY/BjdRGLrd6X60OgvymV/aAUw==}
-
-  '@cloudbase/adapter-wx_mp@1.3.1':
-    resolution: {integrity: sha512-rS0N1aD1a0zc421ds17/HzM4RChQ6T2ixMz87bhPJ1yveqJt/KUqYxiXJDWhZ803wwTmJs8aqNkgugsNusNhbg==}
-
-  '@cloudbase/ai@2.23.0':
-    resolution: {integrity: sha512-0cXwq+LZHgA0vfSUudvcM0r1jZRyQmN+Dco6Dluw2djS1G0VnIlIiP276ToivCCNS83W5lvv7PKqspY+SeAj/A==}
-
-  '@cloudbase/app@2.23.0':
-    resolution: {integrity: sha512-H7KMKhzv4sVv7OpIkjh77DFQKY395aQ9NeScdTvYXD2b2u201YHKVprLaVRgP4N4kNj+xAH6WeA1bEM1OSzZaQ==}
-
-  '@cloudbase/database@1.4.3':
-    resolution: {integrity: sha512-JzmdsGjy9LwzSQQ0Fv4OlNHNK61BRXdJSembTpy4408AQA3q2Ip3N5eB3v9OpAlFMvP/6MGmOQ/ZuUPKfJddJA==}
-
-  '@cloudbase/node-sdk@3.18.3':
-    resolution: {integrity: sha512-qluLOIyPhK8AWmUeS1Qt/S4cV/07pv/L79Cne8beFove775FL9Wi2tSsawZuwGUygIUySljqQaLPUl+lrJ4Leg==}
-    engines: {node: '>=12'}
-
-  '@cloudbase/signature-nodejs@2.2.0':
-    resolution: {integrity: sha512-2y2rieOpJNnBA2MW7sLJKek3iFOjgr8TNicw5qjBkcdVczLR0cFzxMhip75NLCwarFTIAONE3oeNxoQ19eVHcA==}
-
-  '@cloudbase/types@2.23.0':
-    resolution: {integrity: sha512-FvqO+lspbzJWAL/fI2QwC2/HVgj523jxdqtWMjDF9ghiZ+JBIb2edLb1tbH5OhiMTvL9CW22Vl/0RJd93vR5ew==}
-
-  '@cloudbase/utilities@2.23.0':
-    resolution: {integrity: sha512-J+1TYH3Pbyn2GY0QamvFdzFoxZcPvvkDMaE2ivUdTiXg2LfxOO0RMYMv89afKagrtiZTN4hKCIV7rpAfgrDmzQ==}
-
-  '@cloudbase/wx-cloud-client-sdk@1.7.1':
-    resolution: {integrity: sha512-NzLOoYDAeoRh2lRjCtvr6yXu4KPVHqZtPxyv70e+3b2+dZIDE5S5gtU8daE7xS5u4TwPqKB/E2vmgRTYOsCS9w==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -1952,10 +1919,6 @@ packages:
 
   '@mathjax/src@4.1.2':
     resolution: {integrity: sha512-7z3mQCQu4YqC1XyO4hMRkNTO49+5ZN8VtvBYKx+aGIXuGrlUvEAQZzeN/gf3tqZuVU4AI2yf1nYrrL1+BrSxIQ==}
-
-  '@mattiasbuelens/web-streams-adapter@0.1.0':
-    resolution: {integrity: sha512-oV4PyZfwJNtmFWhvlJLqYIX1Nn22ML8FZpS16ZUKv0hg7414xV1fjsGqxQzLT2dyK92TKxsJSwMOd7VNHAtPmA==}
-    engines: {node: '>= 12'}
 
   '@mdit-vue/plugin-component@3.0.2':
     resolution: {integrity: sha512-Fu53MajrZMOAjOIPGMTdTXgHLgGU9KwTqKtYc6WNYtFZNKw04euSfJ/zFg8eBY/2MlciVngkF7Gyc2IL7e8Bsw==}
@@ -3322,9 +3285,6 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/clone@2.1.4':
-    resolution: {integrity: sha512-NKRWaEGaVGVLnGLB2GazvDaZnyweW9FJLLFL5LhywGJB3aqGMT9R/EUoJoSRP4nzofYnZysuDmrEJtJdAqUOtQ==}
-
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
@@ -4059,10 +4019,6 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
-
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -4217,9 +4173,6 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axios@0.33.0:
-    resolution: {integrity: sha512-juz19g7B3UWT9r3+tgRFQf2Bdy6IKDVroiyuVOUrkILVKHpqHL++K1l8ybvfdEP9B/VE72vk8vllbnedVCm/og==}
-
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
     peerDependencies:
@@ -4347,10 +4300,6 @@ packages:
   bson@1.1.6:
     resolution: {integrity: sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==}
     engines: {node: '>=0.6.19'}
-
-  bson@4.7.2:
-    resolution: {integrity: sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==}
-    engines: {node: '>=6.9.0'}
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
@@ -4503,10 +4452,6 @@ packages:
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
-
-  clone@2.1.2:
-    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
-    engines: {node: '>=0.8'}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -5214,15 +5159,6 @@ packages:
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
@@ -5232,10 +5168,6 @@ packages:
 
   form-data@3.0.4:
     resolution: {integrity: sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==}
-    engines: {node: '>= 6'}
-
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   form-data@4.0.6:
@@ -5529,10 +5461,6 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
-  http-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
-    engines: {node: '>= 6'}
-
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -5556,9 +5484,6 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -5633,6 +5558,10 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ini@2.0.0:
+    resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
+    engines: {node: '>=10'}
 
   interpret@2.2.0:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
@@ -5836,6 +5765,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
@@ -5888,9 +5820,6 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
-
-  jwt-decode@3.1.2:
-    resolution: {integrity: sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==}
 
   katex@0.16.45:
     resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
@@ -6070,9 +5999,6 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
-  lodash.clonedeep@4.5.0:
-    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
-
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -6106,17 +6032,11 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
-  lodash.set@4.3.2:
-    resolution: {integrity: sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==}
-
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
-
-  lodash.unset@4.18.0:
-    resolution: {integrity: sha512-7B95k5zjcJtuGuLqxOjT91g0Txwv1PWBlBDGzjW4kM8qgw2qfSgBo1QcIWGUpW9uN/1ZSKX9NHJzVJIgbeR5PQ==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -7080,9 +7000,6 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
-  punycode@1.4.1:
-    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -7949,6 +7866,10 @@ packages:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
 
+  tencentcloud-sdk-nodejs@4.1.260:
+    resolution: {integrity: sha512-ZdodQxNqXcHYeRFNEc2Y9xlWcf+FY4gOnLthZXscvIHGRjtPHbbEWE84AwTC1Meuqx4Uu1Q9bjR9V3jshfWFGg==}
+    engines: {node: '>=10'}
+
   terser-webpack-plugin@5.5.0:
     resolution: {integrity: sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==}
     engines: {node: '>= 10.13.0'}
@@ -7972,9 +7893,6 @@ packages:
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
-
-  text-encoding-shim@1.0.5:
-    resolution: {integrity: sha512-H7yYW+jRn4yhu60ygZ2f/eMhXPITRt4QSUTKzLm+eCaDsdX8avmgWpmtmHAzesjBVUTAypz9odu5RKUjX5HNYA==}
 
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
@@ -8231,6 +8149,9 @@ packages:
       unrun:
         optional: true
 
+  tslib@1.13.0:
+    resolution: {integrity: sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -8414,10 +8335,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  url@0.11.4:
-    resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
-    engines: {node: '>= 0.4'}
-
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -8434,6 +8351,10 @@ packages:
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   validator@9.4.1:
@@ -8736,10 +8657,6 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
-
-  web-streams-polyfill@4.2.0:
-    resolution: {integrity: sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==}
-    engines: {node: '>= 8'}
 
   web-vitals@0.2.4:
     resolution: {integrity: sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==}
@@ -9759,77 +9676,6 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
-  '@cloudbase/adapter-interface@0.7.1': {}
-
-  '@cloudbase/adapter-wx_mp@1.3.1':
-    dependencies:
-      '@cloudbase/adapter-interface': 0.7.1
-      web-streams-polyfill: 4.2.0
-
-  '@cloudbase/ai@2.23.0':
-    dependencies:
-      '@cloudbase/types': 2.23.0
-      '@cloudbase/utilities': 2.23.0
-      '@mattiasbuelens/web-streams-adapter': 0.1.0
-      text-encoding-shim: 1.0.5
-      web-streams-polyfill: 4.2.0
-
-  '@cloudbase/app@2.23.0':
-    dependencies:
-      '@cloudbase/adapter-interface': 0.7.1
-      '@cloudbase/adapter-wx_mp': 1.3.1
-      '@cloudbase/types': 2.23.0
-      '@cloudbase/utilities': 2.23.0
-
-  '@cloudbase/database@1.4.3':
-    dependencies:
-      bson: 4.7.2
-      lodash.clonedeep: 4.5.0
-      lodash.set: 4.3.2
-      lodash.unset: 4.18.0
-
-  '@cloudbase/node-sdk@3.18.3(supports-color@5.5.0)':
-    dependencies:
-      '@cloudbase/ai': 2.23.0
-      '@cloudbase/app': 2.23.0
-      '@cloudbase/database': 1.4.3
-      '@cloudbase/signature-nodejs': 2.2.0
-      '@cloudbase/types': 2.23.0
-      '@cloudbase/wx-cloud-client-sdk': 1.7.1
-      agentkeepalive: 4.6.0
-      axios: 0.33.0
-      form-data: 4.0.5
-      http-proxy-agent: 5.0.0(supports-color@5.5.0)
-      https-proxy-agent: 5.0.1(supports-color@5.5.0)
-      jsonwebtoken: 9.0.3
-      retry: 0.13.1
-      web-streams-polyfill: 4.2.0
-      xml2js: 0.6.2
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@cloudbase/signature-nodejs@2.2.0':
-    dependencies:
-      '@types/clone': 2.1.4
-      clone: 2.1.2
-      is-stream: 2.0.1
-      url: 0.11.4
-
-  '@cloudbase/types@2.23.0':
-    dependencies:
-      '@cloudbase/adapter-interface': 0.7.1
-
-  '@cloudbase/utilities@2.23.0':
-    dependencies:
-      '@cloudbase/adapter-interface': 0.7.1
-      '@cloudbase/types': 2.23.0
-      jwt-decode: 3.1.2
-
-  '@cloudbase/wx-cloud-client-sdk@1.7.1':
-    dependencies:
-      core-js-pure: 3.49.0
-
   '@colors/colors@1.6.0': {}
 
   '@csstools/color-helpers@6.0.2': {}
@@ -10290,7 +10136,7 @@ snapshots:
     dependencies:
       consola: 3.4.2
       detect-libc: 2.1.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@5.5.0)
       node-fetch: 2.7.0
       nopt: 8.1.0
       semver: 7.8.5
@@ -10313,8 +10159,6 @@ snapshots:
       mhchemparser: 4.2.1
       mj-context-menu: 1.0.0
       speech-rule-engine: 5.0.0-rc.1
-
-  '@mattiasbuelens/web-streams-adapter@0.1.0': {}
 
   '@mdit-vue/plugin-component@3.0.2':
     dependencies:
@@ -11283,8 +11127,6 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
-
-  '@types/clone@2.1.4': {}
 
   '@types/cookiejar@2.1.5': {}
 
@@ -12601,17 +12443,13 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  agent-base@6.0.2(supports-color@5.5.0):
+  agent-base@6.0.2:
     dependencies:
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.4: {}
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
@@ -12780,14 +12618,6 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@0.33.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   b4a@1.8.1: {}
 
   babel-plugin-polyfill-corejs3@1.0.0(@babel/core@8.0.1):
@@ -12888,10 +12718,6 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   bson@1.1.6: {}
-
-  bson@4.7.2:
-    dependencies:
-      buffer: 5.7.1
 
   buffer-crc32@0.2.13: {}
 
@@ -13053,8 +12879,6 @@ snapshots:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
-
-  clone@2.1.2: {}
 
   co@4.6.0: {}
 
@@ -13732,8 +13556,6 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.16.0: {}
-
   forever-agent@0.6.1: {}
 
   form-data@2.3.3:
@@ -13747,15 +13569,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
-      mime-types: 2.1.35
-
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   form-data@4.0.6:
@@ -13864,7 +13678,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@6.0.5:
+  get-uri@6.0.5(supports-color@5.5.0):
     dependencies:
       basic-ftp: 5.3.1
       data-uri-to-buffer: 6.0.2
@@ -14122,15 +13936,7 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  http-proxy-agent@5.0.0(supports-color@5.5.0):
-    dependencies:
-      '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2(supports-color@5.5.0)
-      debug: 4.4.3(supports-color@5.5.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@5.5.0):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
@@ -14143,14 +13949,14 @@ snapshots:
       jsprim: 1.4.2
       sshpk: 1.18.0
 
-  https-proxy-agent@5.0.1(supports-color@5.5.0):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@5.5.0)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@5.5.0):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
@@ -14160,10 +13966,6 @@ snapshots:
   human-signals@1.1.1: {}
 
   human-signals@2.1.0: {}
-
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
 
   husky@9.1.7: {}
 
@@ -14222,6 +14024,8 @@ snapshots:
 
   ini@1.3.8: {}
 
+  ini@2.0.0: {}
+
   interpret@2.2.0: {}
 
   invert-kv@1.0.0: {}
@@ -14251,7 +14055,7 @@ snapshots:
 
   is-core-module@2.16.2:
     dependencies:
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   is-decimal@2.0.1: {}
 
@@ -14311,7 +14115,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   is-standalone-pwa@0.1.1: {}
 
@@ -14396,6 +14200,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.0.0
+
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-to-ts@1.6.4:
@@ -14459,8 +14267,6 @@ snapshots:
     dependencies:
       jwa: 2.0.1
       safe-buffer: 5.2.1
-
-  jwt-decode@3.1.2: {}
 
   katex@0.16.45:
     dependencies:
@@ -14702,8 +14508,6 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
-  lodash.clonedeep@4.5.0: {}
-
   lodash.debounce@4.0.8: {}
 
   lodash.escaperegexp@4.1.2: {}
@@ -14726,13 +14530,9 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
-  lodash.set@4.3.2: {}
-
   lodash.truncate@4.4.2: {}
 
   lodash.uniq@4.5.0: {}
-
-  lodash.unset@4.18.0: {}
 
   lodash@4.18.1: {}
 
@@ -15490,14 +15290,14 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pac-proxy-agent@7.2.0:
+  pac-proxy-agent@7.2.0(supports-color@5.5.0):
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
-      get-uri: 6.0.5
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      get-uri: 6.0.5(supports-color@5.5.0)
+      http-proxy-agent: 7.0.2(supports-color@5.5.0)
+      https-proxy-agent: 7.0.6(supports-color@5.5.0)
       pac-resolver: 7.0.1
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -15749,14 +15549,14 @@ snapshots:
       glob: 7.2.3
       yargs: 3.32.0
 
-  proxy-agent@6.4.0:
+  proxy-agent@6.4.0(supports-color@5.5.0):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@5.5.0)
+      https-proxy-agent: 7.0.6(supports-color@5.5.0)
       lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0
+      pac-proxy-agent: 7.2.0(supports-color@5.5.0)
       proxy-from-env: 1.1.0
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -15783,8 +15583,6 @@ snapshots:
       once: 1.4.0
 
   punycode.js@2.3.1: {}
-
-  punycode@1.4.1: {}
 
   punycode@2.3.1: {}
 
@@ -16140,7 +15938,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sandbox@3.1.2:
+  sandbox@3.1.2(supports-color@5.5.0):
     dependencies:
       '@vercel/sandbox': 2.1.1
       async-retry: 1.3.3
@@ -16779,6 +16577,21 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
+  tencentcloud-sdk-nodejs@4.1.260:
+    dependencies:
+      form-data: 3.0.4
+      get-stream: 6.0.1
+      https-proxy-agent: 5.0.1
+      ini: 2.0.0
+      is-stream: 2.0.1
+      json-bigint: 1.0.0
+      node-fetch: 2.7.0
+      tslib: 1.13.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   terser-webpack-plugin@5.5.0(esbuild@0.28.0)(webpack@5.106.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -16801,8 +16614,6 @@ snapshots:
       b4a: 1.8.1
     transitivePeerDependencies:
       - react-native-b4a
-
-  text-encoding-shim@1.0.5: {}
 
   text-hex@1.0.0: {}
 
@@ -17183,6 +16994,8 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
+  tslib@1.13.0: {}
+
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
@@ -17349,11 +17162,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url@0.11.4:
-    dependencies:
-      punycode: 1.4.1
-      qs: 6.15.1
-
   use-sync-external-store@1.6.0(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -17364,13 +17172,15 @@ snapshots:
 
   uuid@7.0.3: {}
 
+  uuid@9.0.1: {}
+
   validator@9.4.1: {}
 
   varint@6.0.0: {}
 
   vary@1.1.2: {}
 
-  vercel@54.18.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
+  vercel@54.18.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(supports-color@5.5.0):
     dependencies:
       '@vercel/backends': 0.8.21(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@vercel/blob': 2.4.0
@@ -17402,8 +17212,8 @@ snapshots:
       esbuild: 0.27.0
       jose: 5.9.6
       luxon: 3.7.2
-      proxy-agent: 6.4.0
-      sandbox: 3.1.2
+      proxy-agent: 6.4.0(supports-color@5.5.0)
+      sandbox: 3.1.2(supports-color@5.5.0)
       smol-toml: 1.5.2
       undici: 5.29.0
       zod: 4.1.11
@@ -17732,8 +17542,6 @@ snapshots:
       graceful-fs: 4.2.11
 
   web-namespaces@2.0.1: {}
-
-  web-streams-polyfill@4.2.0: {}
 
   web-vitals@0.2.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,10 +13,6 @@ allowBuilds:
 enableGlobalVirtualStore: true
 
 overrides:
-  # FIXME: vulnerable
-  '@cloudbase/database>lodash.unset': ^4.18.0
-  # FIXME: vulnerable
-  '@cloudbase/node-sdk>axios': ^0.33.0
   # FIXME: https://github.com/next-theme/utils/issues/42
   '@next-theme/utils>js-yaml': ^5.0.0
   '@waline/api': workspace:*


### PR DESCRIPTION
### Motivation
- Address a reported security concern in the CloudBase dependency by removing `@cloudbase/node-sdk` from the server package and switching to the maintained Tencent Cloud SDK.
- Avoid transitive vulnerable packages and remove related workspace overrides that referenced CloudBase-specific vulnerable dependencies.

### Description
- Replace `@cloudbase/node-sdk` with `tencentcloud-sdk-nodejs` in `packages/server/package.json` and update lockfile metadata to reference `tencentcloud-sdk-nodejs@^4.1.194`.
- Rework the CloudBase storage adapter at `packages/server/src/service/storage/cloudbase.js` to call Tencent Cloud TCB `RunCommands` via `tencentcloud-sdk-nodejs` instead of using the old `cloudbase.init` API, and add a `runCommand` helper wrapping `client.RunCommands`.
- Adapt internal query handling: convert local command/aggregate usages to command objects (find/count/aggregate/insert/update/delete), convert LIKE regexes to `{ $regex: ... }` form, and provide helpers to normalize documents and construct query operators (`_`, `$`).
- Remove CloudBase-specific vulnerable overrides from `pnpm-workspace.yaml` and update `pnpm-lock.yaml` entries to point at the new SDK (lockfile regeneration was adjusted in-file where possible).

### Testing
- Ran a JavaScript syntax check via `node -c packages/server/src/service/storage/cloudbase.js`, which completed successfully. 
- Ran `git diff --check` to validate no whitespace/merge issues, which succeeded. 
- Attempted to regenerate lockfile / install metadata with `pnpm install --lockfile-only` but registry / supply-chain policy and network/proxy restrictions prevented full lockfile resolution, so lockfile metadata could not be fully validated in this environment. 
- Formatting/linters were invoked where possible, but full `pnpm` workspace install and formatter runs could not complete reliably due to environment registry/proxy restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43db7e89f483268b948bc3bfc0d3d3)