### PR TITLE
fix(server): pin dompurify to 3.4.8

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -30,7 +30,7 @@
     "@mdit/plugin-sub": "0.24.2",
     "@mdit/plugin-sup": "0.24.2",
     "akismet": "^2.0.7",
-    "dompurify": "^3.4.11",
+    "dompurify": "3.4.8",
     "fast-csv": "^5.0.7",
     "form-data": "^4.0.6",
     "ip2region": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,8 +501,8 @@ importers:
         specifier: ^2.0.7
         version: 2.0.7
       dompurify:
-        specifier: ^3.4.11
-        version: 3.4.11
+        specifier: 3.4.8
+        version: 3.4.8
       fast-csv:
         specifier: ^5.0.7
         version: 5.0.7
@@ -4876,8 +4876,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.8:
+    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -13346,7 +13346,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.11:
+  dompurify@3.4.8:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
### Motivation

- 回滚并固定 `@waline/vercel`（packages/server）对 `dompurify` 的依赖到精确版本 `3.4.8`，以避免因最新小版本引入的不兼容或安全/行为变更影响服务端。 

### Description

- 将 `packages/server/package.json` 中 `dompurify` 从 `^3.4.11` 改为精确版本 `3.4.8`。 
- 在 `pnpm-lock.yaml` 中同步更新了 `packages/server` 的 `dompurify` specifier/version 条目为 `3.4.8`。 
- 在 `pnpm-lock.yaml` 的 packages / snapshots 区域替换了 `dompurify@3.4.11` 为 `dompurify@3.4.8` 并更新了对应的 `resolution.integrity` 值。 

### Testing

- 运行了一个 `node` 脚本断言来验证 `packages/server/package.json` 的 `dompurify` 值为 `3.4.8` 且 `pnpm-lock.yaml` 包含 `dompurify@3.4.8:` 且不包含 `dompurify@3.4.11:`，断言通过。 
- 尝试执行 `pnpm add dompurify@3.4.8 --filter @waline/vercel` 和 `pnpm --config.runtimeOnFail=ignore install --lockfile-only --offline --filter @waline/vercel` 以更新/校验锁文件，但执行过程中受限于环境（Node.js/pnpm 引擎检查及对 npm registry 的网络访问）导致无法完成远端校验或安装步骤。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4523859c608326ac8b6d88018588c3)