### PR TITLE
fix(admin): handle absolute login redirects

### DIFF
--- a/packages/admin/src/pages/login/index.jsx
+++ b/packages/admin/src/pages/login/index.jsx
@@ -9,6 +9,8 @@ import * as Icons from '../../components/icon';
 import { useCaptcha } from '../../components/useCaptcha.js';
 import { get2FAToken } from '../../services/user.js';
 
+const isAbsoluteHttpURL = (url) => /^https?:\/\//iu.test(url);
+
 export default function Login() {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -36,6 +38,12 @@ export default function Login() {
 
     const defaultRedirect = isAdmin ? '/ui' : '/ui/profile';
     const redirect = isAdmin && query.get('redirect') ? query.get('redirect') : defaultRedirect;
+
+    if (isAbsoluteHttpURL(redirect)) {
+      location.href = redirect;
+
+      return;
+    }
 
     navigate(redirect.replaceAll(/\/+/gu, '/'));
   }, [user, query, navigate]);


### PR DESCRIPTION
### Motivation
- Mobile login redirects include a `redirect` parameter which may be an absolute `http(s)://` URL, and the admin login flow was normalizing slashes with `replaceAll` which corrupted absolute URLs (e.g. `https://` -> `https:/`) leading to white pages on mobile.
- The admin UI should perform a full-page navigation for absolute redirect targets instead of using the React Router `navigate` path normalization.

### Description
- Added an `isAbsoluteHttpURL` helper to `packages/admin/src/pages/login/index.jsx` to detect absolute `http://` or `https://` URLs.
- Updated the login effect to use `location.href = redirect` when `isAbsoluteHttpURL(redirect)` is true, and otherwise continue to call `navigate(redirect.replaceAll(/\/+/gu, '/'))` for relative paths.

### Testing
- Ran `git diff --check` which passed without issues.
- Attempted `pnpm --dir=packages/admin build` but it was blocked by the environment Node.js version being `v24.15.0` while the project requires `^24.17.0`.
- Attempted `pnpm exec oxlint packages/admin/src/pages/login/index.jsx` but it was blocked by the same Node.js version mismatch.
- Attempted `cd packages/admin && NODE_ENV=production ./node_modules/.bin/vite build` which failed due to missing Vite config dependencies in the installed `node_modules` (e.g. `@vitejs/plugin-react`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a11fde33c83269c7a3941d2f91c2d)