### PR TITLE
chore(server): add OAuth objectId debug logs

### DIFF
--- a/packages/server/src/controller/oauth.js
+++ b/packages/server/src/controller/oauth.js
@@ -49,15 +49,33 @@ module.exports = class OAuthController extends think.Controller {
       },
     }).then((resp) => resp.json());
 
+    think.logger.info('[oauth] provider user:', {
+      type,
+      userId: user?.id,
+      email: user?.email,
+      name: user?.name,
+      redirect,
+    });
+
     if (!user?.id) {
       return this.fail(user);
     }
 
     const userBySocial = await this.modelInstance.select({ [type]: user.id });
 
+    think.logger.info('[oauth] userBySocial:', {
+      type,
+      socialId: user.id,
+      userBySocial,
+    });
+
     // when the social account has been linked, then redirect to this linked account profile page. It may be current account or another.
     // If it's another account, user should unlink the social type in that account and then link it.
     if (!think.isEmpty(userBySocial)) {
+      if (!userBySocial[0]?.objectId) {
+        think.logger.error('[oauth] missing objectId in linked user:', userBySocial[0]);
+      }
+
       const token = jwt.sign(userBySocial[0].objectId, this.config('jwtKey'));
 
       if (redirect) {
@@ -100,11 +118,21 @@ module.exports = class OAuthController extends think.Controller {
 
     const cmtUser = await this.modelInstance.add(data);
 
+    think.logger.info('[oauth] created user:', {
+      type,
+      socialId: user.id,
+      cmtUser,
+    });
+
     if (!redirect) {
       return this.success();
     }
 
     // and then generate token!
+    if (!cmtUser?.objectId) {
+      think.logger.error('[oauth] missing objectId in created user:', cmtUser);
+    }
+
     const token = jwt.sign(cmtUser.objectId, this.config('jwtKey'));
 
     this.redirect(`${redirect}${redirect.includes('?') ? '&' : '?'}token=${token}`);


### PR DESCRIPTION
### Motivation
- Add temporary debug logs to help trace why `jwt.sign(...objectId...)` fails with `payload is required` in the OAuth flow.

### Description
- Inserted a provider-user log after fetching third-party user data in `packages/server/src/controller/oauth.js` that outputs `type`, provider `userId`, `email`, `name`, and `redirect`.
- Logged the result of the existing social-account lookup (`userBySocial`) immediately after `this.modelInstance.select(...)` so `userBySocial[0]` can be inspected before token generation.
- Added a guard error log when `userBySocial[0]?.objectId` is missing prior to calling `jwt.sign` on the linked-user path.
- Logged the newly created user (`cmtUser`) after `this.modelInstance.add(data)` and added an error log if `cmtUser?.objectId` is missing before signing the created-user token.

### Testing
- Ran `git diff --check` to verify no whitespace errors and it completed without additional findings.
- Attempted `pnpm exec oxfmt packages/server/src/controller/oauth.js && pnpm exec oxlint packages/server/src/controller/oauth.js` but the run was blocked because the local Node.js is `v24.15.0` while the project requires `^24.17.0`.
- Attempted running local binaries `./node_modules/.bin/oxfmt` and `./node_modules/.bin/oxlint` but those are not available because project dependencies are not installed in `node_modules`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b9d5f2ad4832692ce68ef3ac0ebd4)