### PR TITLE
feat: exchange mobile login codes

### DIFF
--- a/docs/src/en/reference/server/env.md
+++ b/docs/src/en/reference/server/env.md
@@ -216,3 +216,9 @@ Please pay special attention that some mailboxes use separate SMTP passwords.
 | `IP2REGION_DB`                  |                             | customized IPv4 IP query library path (deprecated, use `IP2REGION_DB_V4` instead)                |
 | `IP2REGION_DB_V4`               |                             | customized IPv4 IP query library path. Falls back to `IP2REGION_DB` if not set                   |
 | `IP2REGION_DB_V6`               |                             | customized IPv6 IP query library path. Set this to enable IPv6 address location lookup           |
+
+::: note
+
+Mobile social login redirects back with a short-lived `waline_login_code` and `state`; the client exchanges them for the login token through the server. The legacy `token` redirect parameter is still accepted for compatibility, but is deprecated and will be removed in a future release.
+
+:::

--- a/docs/src/reference/server/env.md
+++ b/docs/src/reference/server/env.md
@@ -228,3 +228,9 @@ SMTP 的用户名通常均支持用户的完整邮箱，而密码大多同邮箱
 | `IP2REGION_DB`                  |                             | 自定义 IPv4 IP 查询库路径（已废弃，建议使用 `IP2REGION_DB_V4`）                                                                                                     |
 | `IP2REGION_DB_V4`               |                             | 自定义 IPv4 IP 查询库路径。如果未设置，将回退到 `IP2REGION_DB`                                                                                                      |
 | `IP2REGION_DB_V6`               |                             | 自定义 IPv6 IP 查询库路径。设置后可启用 IPv6 地址的归属地查询                                                                                                       |
+
+::: note
+
+移动端社交登录会携带短期 `waline_login_code` 和 `state` 跳回评论页，客户端再通过服务端接口交换登录 token。旧的 `token` 跳转参数仍会暂时保留兼容，但已废弃，并将在未来版本移除。
+
+:::

--- a/packages/admin/src/pages/login/index.jsx
+++ b/packages/admin/src/pages/login/index.jsx
@@ -106,7 +106,9 @@ export default function Login() {
 
   const buildOAuthURL = (social) => {
     const redirect = query.get('redirect') || `${basePath}ui/profile`;
-    return `${baseUrl}oauth?type=${encodeURIComponent(social)}&redirect=${encodeURIComponent(redirect)}`;
+    const state = query.get('state') || '';
+
+    return `${baseUrl}oauth?type=${encodeURIComponent(social)}&redirect=${encodeURIComponent(redirect)}&login_state=${encodeURIComponent(state)}`;
   };
 
   return (

--- a/packages/api/src/login.ts
+++ b/packages/api/src/login.ts
@@ -52,6 +52,12 @@ export interface UserInfo {
   type: 'administrator' | 'guest';
 }
 
+const createLoginState = (): string =>
+  globalThis.crypto?.randomUUID?.() ||
+  Array.from(globalThis.crypto.getRandomValues(new Uint8Array(16)), (value) =>
+    value.toString(16).padStart(2, '0'),
+  ).join('');
+
 const isMobile = (): boolean => {
   const ua = navigator.userAgent;
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/iu.test(ua);
@@ -67,7 +73,9 @@ export const login = ({
   const top = (window.innerHeight - height) / 2;
 
   if (isMobile()) {
-    location.href = `${serverURL.replace(/\/$/u, '')}/ui/login?lng=${encodeURIComponent(lang)}&redirect=${encodeURIComponent(location.href)}`;
+    const state = createLoginState();
+
+    location.href = `${serverURL.replace(/\/$/u, '')}/ui/login?lng=${encodeURIComponent(lang)}&redirect=${encodeURIComponent(location.href)}&state=${encodeURIComponent(state)}`;
 
     // On mobile, we perform a full-page redirect; the login flow is handled entirely
     // in the redirected page, so this promise intentionally never resolves to avoid

--- a/packages/client/src/components/WalineComment.vue
+++ b/packages/client/src/components/WalineComment.vue
@@ -231,17 +231,27 @@ onMounted(async () => {
   );
 
   const qs = new URLSearchParams(location.search);
+  const loginCode = qs.get('waline_login_code');
+  const loginState = qs.get('state') || '';
   const token = qs.get('token');
 
-  if (!token) {
+  if (!loginCode && !token) {
     return;
   }
 
-  const resp = await fetch(`${config?.value.serverURL}/token`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  })
+  const resp = await (loginCode
+    ? fetch(`${config?.value.serverURL}/oauth/code`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ code: loginCode, state: loginState }),
+      })
+    : fetch(`${config?.value.serverURL}/token`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }))
     .then((res) => res.json())
     .catch((err) => {
       // oxlint-disable-next-line no-console
@@ -250,10 +260,12 @@ onMounted(async () => {
     });
 
   if (!resp.errno && resp?.data?.objectId) {
-    userInfo.value = { ...resp.data, token };
+    userInfo.value = { ...resp.data, token: resp.data.token || token };
   }
 
   const url = new URL(window.location.href);
+  url.searchParams.delete('waline_login_code');
+  url.searchParams.delete('state');
   url.searchParams.delete('token');
 
   history.replaceState(

--- a/packages/server/src/controller/oauth.js
+++ b/packages/server/src/controller/oauth.js
@@ -1,5 +1,13 @@
 const jwt = require('jsonwebtoken');
 
+const buildLoginRedirect = (redirect, token, state) => {
+  const params = state
+    ? { waline_login_code: think.service('login-code').create({ token, state }).code, state }
+    : { waline_login_code: think.service('login-code').create({ token, state }).code };
+
+  return think.buildUrl(redirect, params);
+};
+
 module.exports = class OAuthController extends think.Controller {
   constructor(ctx) {
     super(ctx);
@@ -7,7 +15,7 @@ module.exports = class OAuthController extends think.Controller {
   }
 
   async indexAction() {
-    const { code, state, type, redirect } = this.get();
+    const { code, state, type, redirect, login_state: loginState = '' } = this.get();
     const { oauthUrl } = this.config();
 
     if (!code) {
@@ -15,6 +23,7 @@ module.exports = class OAuthController extends think.Controller {
       const redirectUrl = think.buildUrl(`${serverURL}/api/oauth`, {
         redirect,
         type,
+        login_state: loginState,
       });
 
       this.redirect(
@@ -34,6 +43,7 @@ module.exports = class OAuthController extends think.Controller {
       const redirectUrl = think.buildUrl(`${serverURL}/api/oauth`, {
         redirect,
         type,
+        login_state: loginState,
       });
 
       params.state = think.buildUrl(undefined, {
@@ -61,7 +71,7 @@ module.exports = class OAuthController extends think.Controller {
       const token = jwt.sign(userBySocial[0].objectId, this.config('jwtKey'));
 
       if (redirect) {
-        this.redirect(think.buildUrl(redirect, { token }));
+        this.redirect(buildLoginRedirect(redirect, token, loginState));
         return;
       }
 
@@ -107,6 +117,46 @@ module.exports = class OAuthController extends think.Controller {
     // and then generate token!
     const token = jwt.sign(cmtUser.objectId, this.config('jwtKey'));
 
-    this.redirect(`${redirect}${redirect.includes('?') ? '&' : '?'}token=${token}`);
+    this.redirect(buildLoginRedirect(redirect, token, loginState));
+  }
+
+  async codeAction() {
+    const { code, state = '' } = this.post();
+    const token = think.service('login-code').exchange({ code, state });
+
+    if (!token) {
+      return this.fail();
+    }
+
+    let userId = '';
+
+    try {
+      userId = jwt.verify(token, this.config('jwtKey'));
+    } catch (err) {
+      think.logger.debug(err);
+      return this.fail();
+    }
+    const user = await this.modelInstance.select(
+      { objectId: userId, type: ['!=', 'banned'] },
+      {
+        field: [
+          'id',
+          'email',
+          'url',
+          'display_name',
+          'type',
+          'avatar',
+          '2fa',
+          'label',
+          ...this.ctx.state.oauthServices.map(({ name }) => name),
+        ],
+      },
+    );
+
+    if (think.isEmpty(user)) {
+      return this.fail();
+    }
+
+    return this.success({ ...user[0], token });
   }
 };

--- a/packages/server/src/logic/oauth.js
+++ b/packages/server/src/logic/oauth.js
@@ -7,4 +7,24 @@ module.exports = class OAuthLogic extends Base {
    * @apiVersion 0.0.1
    */
   indexAction() {}
+
+  /**
+   * @api {POST} /api/oauth/code exchange short login code
+   * @apiGroup OAuth
+   * @apiVersion 0.0.1
+   *
+   * @apiParam {String} code short login code
+   * @apiParam {String} state login state
+   */
+  codeAction() {
+    this.rules = {
+      code: {
+        required: true,
+        string: true,
+      },
+      state: {
+        string: true,
+      },
+    };
+  }
 };

--- a/packages/server/src/service/login-code.js
+++ b/packages/server/src/service/login-code.js
@@ -1,0 +1,27 @@
+const crypto = require('node:crypto');
+
+const LOGIN_CODE_TTL = 5 * 60 * 1000;
+const codes = new Map();
+
+module.exports = class extends think.Service {
+  create({ token, state = '' }) {
+    const code = crypto.randomBytes(32).toString('base64url');
+    const expiresAt = Date.now() + LOGIN_CODE_TTL;
+
+    codes.set(code, { token, state, expiresAt });
+
+    return { code, state };
+  }
+
+  exchange({ code, state = '' }) {
+    const data = codes.get(code);
+
+    codes.delete(code);
+
+    if (!data || data.expiresAt < Date.now() || data.state !== state) {
+      return null;
+    }
+
+    return data.token;
+  }
+};


### PR DESCRIPTION
### Motivation

- Mobile OAuth redirects should avoid placing long-lived `token` values in the redirect URL and instead use a short-lived one-time code with an optional `state` for security and compatibility. 
- Client-side comment pages must be able to exchange that short-lived code for the real login token and immediately clean URL parameters. 
- Keep the old `token` redirect parameter working for a transition period and document the new flow as the preferred approach.

### Description

- Add a new short-lived one-time login code service at `packages/server/src/service/login-code.js` that creates and exchanges `waline_login_code` values (TTL 5 minutes). 
- Modify `packages/server/src/controller/oauth.js` to emit `waline_login_code` + optional `state` via `buildLoginRedirect` instead of directly appending `token`, and add a POST `/oauth/code` handler (`codeAction`) that exchanges the short code for the token and returns user info. 
- Add validation rules for the exchange endpoint in `packages/server/src/logic/oauth.js`. 
- Update the client to initiate and carry a `state` for mobile flows in `packages/api/src/login.ts` and include `login_state` in admin OAuth URLs in `packages/admin/src/pages/login/index.jsx`. 
- Update the comment widget in `packages/client/src/components/WalineComment.vue` to accept either the legacy `token` or the new `waline_login_code`, call `POST /oauth/code` when `waline_login_code` is present, set `userInfo`, and immediately remove `waline_login_code`, `state`, and `token` from the URL. 
- Document the behavior and deprecation note for the legacy `token` redirect parameter in `docs/src/en/reference/server/env.md` and `docs/src/reference/server/env.md`.

### Testing

- Ran `node --check` on `packages/server/src/controller/oauth.js`, `packages/server/src/logic/oauth.js`, and `packages/server/src/service/login-code.js`, which completed successfully. 
- Ran `git diff --check` which reported no whitespace or diff errors. 
- Attempted `pnpm exec oxlint ... --fix` for code style, but it was blocked by the environment Node.js version requirement (`^24.17.0` vs available `v24.15.0`), so automated lint autofixes were not applied in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b8dd5176883268365fae95b8a3a8f)