### PR TITLE
feat: centralize login completion flow

### DIFF
--- a/packages/admin/src/pages/login/index.jsx
+++ b/packages/admin/src/pages/login/index.jsx
@@ -1,18 +1,19 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link, useNavigate } from 'react-router';
+import { Link } from 'react-router';
 
 import Header from '../../components/Header.jsx';
 // oxlint-disable-next-line import/no-namespace
 import * as Icons from '../../components/icon';
 import { useCaptcha } from '../../components/useCaptcha.js';
+import { getUserInfo } from '../../services/auth.js';
 import { get2FAToken } from '../../services/user.js';
+import { finishLogin } from '../../utils/finishLogin.js';
 
 export default function Login() {
   const { t } = useTranslation();
   const dispatch = useDispatch();
-  const navigate = useNavigate();
   const user = useSelector((state) => state.user);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
@@ -28,17 +29,20 @@ export default function Login() {
   const query = useMemo(() => new URLSearchParams(location.search), []);
 
   useEffect(() => {
-    if (!user || !user.objectId) {
+    const token = query.get('token');
+
+    if (!token || user?.objectId) {
       return;
     }
 
-    const isAdmin = user.type === 'administrator';
+    window.TOKEN = token;
+    sessionStorage.setItem('TOKEN', token);
 
-    const defaultRedirect = isAdmin ? '/ui' : '/ui/profile';
-    const redirect = isAdmin && query.get('redirect') ? query.get('redirect') : defaultRedirect;
-
-    navigate(redirect.replaceAll(/\/+/gu, '/'));
-  }, [user, query, navigate]);
+    void getUserInfo().then(async (loginUser) => {
+      await dispatch.user.setUser(loginUser);
+      await finishLogin({ token, user: loginUser, remember: false });
+    });
+  }, [user, query, dispatch]);
 
   const onSubmit = async (event) => {
     event.preventDefault();
@@ -105,8 +109,16 @@ export default function Login() {
     : ['oidc', 'qq', 'weibo', 'github', 'twitter', 'facebook'];
 
   const buildOAuthURL = (social) => {
-    const redirect = query.get('redirect') || `${basePath}ui/profile`;
-    return `${baseUrl}oauth?type=${encodeURIComponent(social)}&redirect=${encodeURIComponent(redirect)}`;
+    const loginUrl = new URL(`${location.origin}${basePath}ui/login`);
+    const redirect = query.get('redirect');
+
+    if (redirect) {
+      loginUrl.searchParams.set('redirect', redirect);
+    }
+
+    return `${baseUrl}oauth?type=${encodeURIComponent(social)}&redirect=${encodeURIComponent(
+      loginUrl.pathname + loginUrl.search,
+    )}`;
   };
 
   return (

--- a/packages/admin/src/services/auth.js
+++ b/packages/admin/src/services/auth.js
@@ -13,6 +13,9 @@ export const login = ({ email, password, code, recaptchaV3, turnstile }) =>
     body: { email, password, code, recaptchaV3, turnstile },
   });
 
+export const validateRedirect = (redirect) =>
+  request(`redirect?url=${encodeURIComponent(redirect)}`);
+
 export const logout = () => {
   window.TOKEN = null;
   sessionStorage.removeItem('TOKEN');

--- a/packages/admin/src/store/user.js
+++ b/packages/admin/src/store/user.js
@@ -1,5 +1,6 @@
 import { forgot, getUserInfo, login, logout, register } from '../services/auth.js';
 import { updateProfile } from '../services/user.js';
+import { finishLogin } from '../utils/finishLogin.js';
 
 export const user = {
   state: null,
@@ -22,9 +23,9 @@ export const user = {
       if (window.opener) {
         const localToken = localStorage.getItem('TOKEN');
         const remember = Boolean(localToken);
-        const token = localToken ?? window.TOKEN ?? sessionStorage.getItem('token');
+        const token = localToken ?? window.TOKEN ?? sessionStorage.getItem('TOKEN');
 
-        window.opener.postMessage({ type: 'userInfo', data: { token, remember, ...user } }, '*');
+        await finishLogin({ token, user, remember });
       }
 
       return dispatch.user.setUser(user);
@@ -45,9 +46,7 @@ export const user = {
           localStorage.setItem('TOKEN', token);
         }
 
-        if (window.opener) {
-          window.opener.postMessage({ type: 'userInfo', data: { token, remember, ...user } }, '*');
-        }
+        await finishLogin({ token, user, remember });
       }
 
       return dispatch.user.setUser(user);

--- a/packages/admin/src/utils/finishLogin.js
+++ b/packages/admin/src/utils/finishLogin.js
@@ -1,0 +1,65 @@
+import { validateRedirect } from '../services/auth.js';
+
+const getDefaultRedirect = (user) => (user?.type === 'administrator' ? '/ui' : '/ui/profile');
+
+const normalizeRedirect = (redirect) => {
+  if (!redirect) {
+    return '';
+  }
+
+  try {
+    return new URL(redirect, location.origin).href;
+  } catch {
+    return '';
+  }
+};
+
+const getTargetOrigin = (redirect) => {
+  const normalizedRedirect = normalizeRedirect(redirect);
+
+  if (normalizedRedirect) {
+    return new URL(normalizedRedirect).origin;
+  }
+
+  if (document.referrer) {
+    return new URL(document.referrer).origin;
+  }
+
+  return location.origin;
+};
+
+export const finishLogin = async ({ token, user, remember }) => {
+  if (window.opener) {
+    const redirect = new URLSearchParams(location.search).get('redirect');
+
+    window.opener.postMessage(
+      { type: 'userInfo', data: { token, remember, ...user } },
+      getTargetOrigin(redirect),
+    );
+
+    return;
+  }
+
+  const query = new URLSearchParams(location.search);
+  const redirect = query.get('redirect');
+  const fallback = getDefaultRedirect(user);
+
+  if (!redirect) {
+    location.href = fallback;
+
+    return;
+  }
+
+  const { valid, url } = await validateRedirect(redirect).catch(() => ({ valid: false }));
+
+  if (valid && url) {
+    const redirectUrl = new URL(url, location.origin);
+
+    redirectUrl.searchParams.set('token', token);
+    location.href = redirectUrl.href;
+
+    return;
+  }
+
+  location.href = fallback;
+};

--- a/packages/api/src/login.ts
+++ b/packages/api/src/login.ts
@@ -78,7 +78,7 @@ export const login = ({
   }
 
   const handler = window.open(
-    `${serverURL.replace(/\/$/u, '')}/ui/login?lng=${encodeURIComponent(lang)}`,
+    `${serverURL.replace(/\/$/u, '')}/ui/login?lng=${encodeURIComponent(lang)}&redirect=${encodeURIComponent(location.href)}`,
     '_blank',
     `width=${width},height=${height},left=${left},top=${top},scrollbars=no,resizable=no,status=no,location=no,toolbar=no,menubar=no`,
   );

--- a/packages/server/src/controller/redirect.js
+++ b/packages/server/src/controller/redirect.js
@@ -1,0 +1,64 @@
+const BaseRest = require('./rest.js');
+
+module.exports = class extends BaseRest {
+  getAction() {
+    const redirectUrl = this.get('url');
+
+    return this.success({
+      valid: this.isValidRedirect(redirectUrl),
+      url: redirectUrl,
+    });
+  }
+
+  isValidRedirect(redirectUrl) {
+    if (!redirectUrl || typeof redirectUrl !== 'string') {
+      return false;
+    }
+
+    if (redirectUrl.startsWith('/') && !redirectUrl.startsWith('//')) {
+      return true;
+    }
+
+    let hostname = '';
+
+    try {
+      hostname = new URL(redirectUrl).hostname;
+    } catch {
+      return false;
+    }
+
+    let { secureDomains } = this.config();
+
+    secureDomains = secureDomains
+      ? think.isArray(secureDomains)
+        ? secureDomains
+        : [secureDomains]
+      : [];
+    secureDomains = [
+      ...secureDomains,
+      'localhost',
+      '127.0.0.1',
+      ...this.ctx.state.oauthServices.map(({ origin }) => origin),
+    ];
+
+    return secureDomains.filter(Boolean).some((domain) => {
+      if (typeof domain === 'string' && domain.startsWith('/') && domain.endsWith('/')) {
+        try {
+          return new RegExp(domain.slice(1, -1), 'u').test(hostname);
+        } catch (err) {
+          think.logger.debug(err);
+
+          return false;
+        }
+      }
+
+      return domain === hostname;
+    });
+  }
+
+  postAction() {}
+
+  deleteAction() {}
+
+  putAction() {}
+};


### PR DESCRIPTION
### Motivation
- Provide a single, secure completion path for both normal and OAuth logins to avoid duplicated opener/redirect logic.
- Ensure `postMessage` replies target a safe origin and that client-side redirects are validated by the server to prevent unsafe forwardings.
- Make popup and mobile login flows share the same redirect handling so post-login behavior is consistent.

### Description
- Add a shared helper `finishLogin({ token, user, remember })` in `packages/admin/src/utils/finishLogin.js` that handles `window.opener` detection, targeted `postMessage` origin selection, server-side redirect validation via `validateRedirect`, token forwarding to valid redirects, and safe fallback navigation to a default page (`/ui` or `/ui/profile`).
- Wire `finishLogin` into admin flows by replacing ad-hoc opener messaging in `packages/admin/src/store/user.js` and by finishing OAuth/token completion in `packages/admin/src/pages/login/index.jsx` when a `token` query param is present.
- Add a client helper `validateRedirect` in `packages/admin/src/services/auth.js` and a new server controller `packages/server/src/controller/redirect.js` that returns whether a redirect URL is valid against configured `secureDomains` (including support for regex entries and local hosts) and allows safe relative paths.
- Ensure popup login includes the current page as the `redirect` parameter (desktop and mobile) in `packages/api/src/login.ts` so the opener can compute a safe target origin for `postMessage`.

### Testing
- Ran `node --check packages/server/src/controller/redirect.js` which succeeded.
- Ran `git diff --check` which reported no whitespace issues and succeeded.
- Attempted to run formatting (`pnpm exec oxfmt ...`) but it could not run in this environment because Node.js is `v24.15.0` while the project requires `^24.17.0`, and `oxfmt` was not available locally; formatting/lint steps were therefore not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b8de8c99483269a86abf6bd0fa90c)