### PR TITLE
Show PR source metadata on Vercel previews

### DIFF
--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -77,7 +77,9 @@ jobs:
             const marker = '<!-- waline-vercel-preview -->';
             const prNumber = context.payload.pull_request.number;
             const commit = context.payload.pull_request.head.sha;
-            const body = `${marker}\n### Vercel Preview\n\n⏳ Building \`@waline/api\` and \`@waline/client\`, then deploying to Vercel...\n\n- PR: #${prNumber}\n- Commit: ${commit}\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+            const prUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`;
+            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${commit}`;
+            const body = `${marker}\n### Vercel Preview\n\n⏳ Building \`@waline/api\` and \`@waline/client\`, then deploying to Vercel...\n\n- PR: [#${prNumber}](${prUrl})\n- Commit: [${commit}](${commitUrl})\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -100,7 +102,9 @@ jobs:
           cp packages/client/dist/waline.js packages/client/dist/waline.css packages/server/__tests__/fixtures/vercel/client/
           sed -i \
             -e 's#__WALINE_PREVIEW_PR__#${{ github.event.pull_request.number }}#g' \
+            -e 's#__WALINE_PREVIEW_PR_URL__#${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}#g' \
             -e 's#__WALINE_PREVIEW_COMMIT__#${{ github.event.pull_request.head.sha }}#g' \
+            -e 's#__WALINE_PREVIEW_COMMIT_URL__#${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.pull_request.head.sha }}#g' \
             packages/server/__tests__/fixtures/vercel/index.html
           # Pack the server from the current PR checkout and install that local tarball in the fixture.
           pnpm --dir packages/server pack --pack-destination ../../packages/server/__tests__/fixtures/vercel
@@ -161,7 +165,9 @@ jobs:
               : `https://${process.env.PREVIEW_URL}`;
             const prNumber = context.payload.pull_request.number;
             const commit = context.payload.pull_request.head.sha;
-            const body = `${marker}\n### Vercel Preview\n\n✅ Deployment is ready.\n\n- Preview: ${targetUrl}\n- PR: #${prNumber}\n- Commit: ${commit}\n- Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const prUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`;
+            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${commit}`;
+            const body = `${marker}\n### Vercel Preview\n\n✅ Deployment is ready.\n\n- Preview: ${targetUrl}\n- PR: [#${prNumber}](${prUrl})\n- Commit: [${commit}](${commitUrl})\n- Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -77,9 +77,7 @@ jobs:
             const marker = '<!-- waline-vercel-preview -->';
             const prNumber = context.payload.pull_request.number;
             const commit = context.payload.pull_request.head.sha;
-            const prUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`;
-            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${commit}`;
-            const body = `${marker}\n### Vercel Preview\n\n⏳ Building \`@waline/api\` and \`@waline/client\`, then deploying to Vercel...\n\n- PR: [#${prNumber}](${prUrl})\n- Commit: [${commit}](${commitUrl})\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+            const body = `${marker}\n### Vercel Preview\n\n⏳ Building \`@waline/api\` and \`@waline/client\`, then deploying to Vercel...\n\n- PR: #${prNumber}\n- Commit: ${commit}\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -165,9 +163,7 @@ jobs:
               : `https://${process.env.PREVIEW_URL}`;
             const prNumber = context.payload.pull_request.number;
             const commit = context.payload.pull_request.head.sha;
-            const prUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/pull/${prNumber}`;
-            const commitUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/commit/${commit}`;
-            const body = `${marker}\n### Vercel Preview\n\n✅ Deployment is ready.\n\n- Preview: ${targetUrl}\n- PR: [#${prNumber}](${prUrl})\n- Commit: [${commit}](${commitUrl})\n- Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `${marker}\n### Vercel Preview\n\n✅ Deployment is ready.\n\n- Preview: ${targetUrl}\n- Vercel Deployment: [Open deployment](${targetUrl})\n- PR: #${prNumber}\n- Commit: ${commit}\n- Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -75,7 +75,9 @@ jobs:
         with:
           script: |
             const marker = '<!-- waline-vercel-preview -->';
-            const body = `${marker}\n### Vercel Preview\n\n⏳ Building \`@waline/api\` and \`@waline/client\`, then deploying to Vercel...\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+            const prNumber = context.payload.pull_request.number;
+            const commit = context.payload.pull_request.head.sha;
+            const body = `${marker}\n### Vercel Preview\n\n⏳ Building \`@waline/api\` and \`@waline/client\`, then deploying to Vercel...\n\n- PR: #${prNumber}\n- Commit: ${commit}\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -96,6 +98,10 @@ jobs:
           rm -rf packages/server/__tests__/fixtures/vercel/client
           mkdir -p packages/server/__tests__/fixtures/vercel/client
           cp packages/client/dist/waline.js packages/client/dist/waline.css packages/server/__tests__/fixtures/vercel/client/
+          sed -i \
+            -e 's#__WALINE_PREVIEW_PR__#${{ github.event.pull_request.number }}#g' \
+            -e 's#__WALINE_PREVIEW_COMMIT__#${{ github.event.pull_request.head.sha }}#g' \
+            packages/server/__tests__/fixtures/vercel/index.html
           # Pack the server from the current PR checkout and install that local tarball in the fixture.
           pnpm --dir packages/server pack --pack-destination ../../packages/server/__tests__/fixtures/vercel
           mv packages/server/__tests__/fixtures/vercel/waline-vercel-*.tgz packages/server/__tests__/fixtures/vercel/waline-vercel-current-pr.tgz
@@ -153,7 +159,9 @@ jobs:
             const targetUrl = process.env.PREVIEW_URL.startsWith('http')
               ? process.env.PREVIEW_URL
               : `https://${process.env.PREVIEW_URL}`;
-            const body = `${marker}\n### Vercel Preview\n\n✅ Deployment is ready.\n\n- Preview: ${targetUrl}\n- Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const prNumber = context.payload.pull_request.number;
+            const commit = context.payload.pull_request.head.sha;
+            const body = `${marker}\n### Vercel Preview\n\n✅ Deployment is ready.\n\n- Preview: ${targetUrl}\n- PR: #${prNumber}\n- Commit: ${commit}\n- Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -125,7 +125,15 @@ jobs:
             echo "Unable to find Vercel preview URL in deploy output" >&2
             exit 1
           fi
+          inspect_url=$(awk 'match($0, /https:\/\/vercel.com\/[^[:space:]]+/) { value=substr($0, RSTART, RLENGTH) } END { print value }' vercel-deploy.log)
+          vercel_deployment_id=${inspect_url##*/}
+          if [ -z "$vercel_deployment_id" ]; then
+            echo "Unable to find Vercel deployment ID in deploy output" >&2
+            exit 1
+          fi
+          deployment_url="https://vercel.com/${VERCEL_ORG_ID}/${VERCEL_PROJECT_ID}/${vercel_deployment_id}"
           echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
           echo "$url"
 
       - name: Mark deployment successful
@@ -155,6 +163,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           PREVIEW_URL: ${{ steps.vercel.outputs.url }}
+          VERCEL_DEPLOYMENT_URL: ${{ steps.vercel.outputs.deployment_url }}
         with:
           script: |
             const marker = '<!-- waline-vercel-preview -->';
@@ -163,7 +172,7 @@ jobs:
               : `https://${process.env.PREVIEW_URL}`;
             const prNumber = context.payload.pull_request.number;
             const commit = context.payload.pull_request.head.sha;
-            const body = `${marker}\n### Vercel Preview\n\n✅ Deployment is ready.\n\n- Preview: ${targetUrl}\n- Vercel Deployment: [Open deployment](${targetUrl})\n- PR: #${prNumber}\n- Commit: ${commit}\n- Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `${marker}\n### Vercel Preview\n\n✅ Deployment is ready.\n\n- Preview: ${targetUrl}\n- Vercel Deployment: [Open deployment](${process.env.VERCEL_DEPLOYMENT_URL})\n- PR: #${prNumber}\n- Commit: ${commit}\n- Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -125,13 +125,7 @@ jobs:
             echo "Unable to find Vercel preview URL in deploy output" >&2
             exit 1
           fi
-          inspect_url=$(awk 'match($0, /https:\/\/vercel.com\/[^[:space:]]+/) { value=substr($0, RSTART, RLENGTH) } END { print value }' vercel-deploy.log)
-          vercel_deployment_id=${inspect_url##*/}
-          if [ -z "$vercel_deployment_id" ]; then
-            echo "Unable to find Vercel deployment ID in deploy output" >&2
-            exit 1
-          fi
-          deployment_url="https://vercel.com/${VERCEL_ORG_ID}/${VERCEL_PROJECT_ID}/${vercel_deployment_id}"
+          deployment_url=$(awk '/Inspect/ && match($0, /https:\/\/vercel.com\/[^[:space:]]+/) { value=substr($0, RSTART, RLENGTH) } END { print value }' vercel-deploy.log)
           echo "url=$url" >> "$GITHUB_OUTPUT"
           echo "deployment_url=$deployment_url" >> "$GITHUB_OUTPUT"
           echo "$url"
@@ -172,7 +166,10 @@ jobs:
               : `https://${process.env.PREVIEW_URL}`;
             const prNumber = context.payload.pull_request.number;
             const commit = context.payload.pull_request.head.sha;
-            const body = `${marker}\n### Vercel Preview\n\n✅ Deployment is ready.\n\n- Preview: ${targetUrl}\n- Vercel Deployment: [Open deployment](${process.env.VERCEL_DEPLOYMENT_URL})\n- PR: #${prNumber}\n- Commit: ${commit}\n- Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const deploymentLine = process.env.VERCEL_DEPLOYMENT_URL
+              ? `\n- Vercel Deployment: [Open deployment](${process.env.VERCEL_DEPLOYMENT_URL})`
+              : '';
+            const body = `${marker}\n### Vercel Preview\n\n✅ Deployment is ready.\n\n- Preview: ${targetUrl}${deploymentLine}\n- PR: #${prNumber}\n- Commit: ${commit}\n- Workflow: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/packages/server/__tests__/fixtures/vercel/index.html
+++ b/packages/server/__tests__/fixtures/vercel/index.html
@@ -44,6 +44,7 @@
       window.waline = init({
         ...queryConfig,
         el: '#waline',
+        path: queryConfig.path || 'walinejs/waline#__WALINE_PREVIEW_PR__',
         serverURL:
           queryConfig.serverURL ||
           location.protocol + '//' + location.host + location.pathname.replace(/\/+$/, ''),

--- a/packages/server/__tests__/fixtures/vercel/index.html
+++ b/packages/server/__tests__/fixtures/vercel/index.html
@@ -14,8 +14,8 @@
         style="margin: 1rem 0; padding: 1rem; border: 1px solid #ddd; border-radius: 8px"
       >
         <p style="margin: 0 0 0.5rem"><strong>Preview source</strong></p>
-        <p style="margin: 0">PR #__WALINE_PREVIEW_PR__</p>
-        <p style="margin: 0; word-break: break-all">__WALINE_PREVIEW_COMMIT__</p>
+        <p style="margin: 0">PR <a href="__WALINE_PREVIEW_PR_URL__">#__WALINE_PREVIEW_PR__</a></p>
+        <p style="margin: 0; word-break: break-all">Commit <a href="__WALINE_PREVIEW_COMMIT_URL__">__WALINE_PREVIEW_COMMIT__</a></p>
       </section>
       <div id="waline"></div>
     </main>

--- a/packages/server/__tests__/fixtures/vercel/index.html
+++ b/packages/server/__tests__/fixtures/vercel/index.html
@@ -23,9 +23,45 @@
     <script type="module">
       import { init } from '/client/waline.js';
 
+      const parseConfigValue = (value) => {
+        try {
+          return JSON.parse(value);
+        } catch {
+          return value;
+        }
+      };
+
+      const searchParams = new URLSearchParams(location.search);
+      const queryConfig = {};
+
+      if (searchParams.has('config')) {
+        const config = parseConfigValue(searchParams.get('config'));
+
+        if (config && typeof config === 'object' && !Array.isArray(config)) {
+          Object.assign(queryConfig, config);
+        }
+      }
+
+      searchParams.delete('config');
+
+      searchParams.forEach((value, key) => {
+        const parsedValue = parseConfigValue(value);
+
+        if (key in queryConfig) {
+          queryConfig[key] = Array.isArray(queryConfig[key])
+            ? [...queryConfig[key], parsedValue]
+            : [queryConfig[key], parsedValue];
+        } else {
+          queryConfig[key] = parsedValue;
+        }
+      });
+
       window.waline = init({
+        ...queryConfig,
         el: '#waline',
-        serverURL: location.protocol + '//' + location.host + location.pathname.replace(/\/+$/, ''),
+        serverURL:
+          queryConfig.serverURL ||
+          location.protocol + '//' + location.host + location.pathname.replace(/\/+$/, ''),
       });
     </script>
   </body>

--- a/packages/server/__tests__/fixtures/vercel/index.html
+++ b/packages/server/__tests__/fixtures/vercel/index.html
@@ -9,6 +9,14 @@
   <body>
     <main style="max-width: 800px; margin: 0 auto; padding: 2rem 1rem">
       <h1>Waline Preview</h1>
+      <section
+        aria-label="Preview deployment metadata"
+        style="margin: 1rem 0; padding: 1rem; border: 1px solid #ddd; border-radius: 8px"
+      >
+        <p style="margin: 0 0 0.5rem"><strong>Preview source</strong></p>
+        <p style="margin: 0">PR #__WALINE_PREVIEW_PR__</p>
+        <p style="margin: 0; word-break: break-all">__WALINE_PREVIEW_COMMIT__</p>
+      </section>
       <div id="waline"></div>
     </main>
 

--- a/packages/server/__tests__/fixtures/vercel/index.html
+++ b/packages/server/__tests__/fixtures/vercel/index.html
@@ -23,38 +23,23 @@
     <script type="module">
       import { init } from '/client/waline.js';
 
-      const parseConfigValue = (value) => {
+      const parseQueryConfig = () => {
+        const value = new URLSearchParams(location.search).get('config');
+
+        if (!value) return {};
+
         try {
-          return JSON.parse(value);
+          const config = JSON.parse(value);
+
+          return config && typeof config === 'object' && !Array.isArray(config)
+            ? config
+            : {};
         } catch {
-          return value;
+          return {};
         }
       };
 
-      const searchParams = new URLSearchParams(location.search);
-      const queryConfig = {};
-
-      if (searchParams.has('config')) {
-        const config = parseConfigValue(searchParams.get('config'));
-
-        if (config && typeof config === 'object' && !Array.isArray(config)) {
-          Object.assign(queryConfig, config);
-        }
-      }
-
-      searchParams.delete('config');
-
-      searchParams.forEach((value, key) => {
-        const parsedValue = parseConfigValue(value);
-
-        if (key in queryConfig) {
-          queryConfig[key] = Array.isArray(queryConfig[key])
-            ? [...queryConfig[key], parsedValue]
-            : [queryConfig[key], parsedValue];
-        } else {
-          queryConfig[key] = parsedValue;
-        }
-      });
+      const queryConfig = parseQueryConfig();
 
       window.waline = init({
         ...queryConfig,


### PR DESCRIPTION
### Motivation

- Make Vercel preview deployments easier to trace back to the originating PR and commit by surfacing that metadata in the preview page and in the preview workflow comments.

### Description

- Add a preview metadata block to the Vercel fixture page at `packages/server/__tests__/fixtures/vercel/index.html` showing `PR #__WALINE_PREVIEW_PR__` and `__WALINE_PREVIEW_COMMIT__` placeholders.
- During the `Build preview artifacts` step in `.github/workflows/vercel-preview-deploy.yml`, replace the placeholders with `${{ github.event.pull_request.number }}` and `${{ github.event.pull_request.head.sha }}` using `sed` before packaging and deploying.
- Include the PR number and commit SHA in both the initial "building" preview comment and the successful deployment preview comment by adding `context.payload.pull_request.number` and `context.payload.pull_request.head.sha` to the comment bodies.

### Testing

- Ran `git diff --check` to ensure no whitespace or index issues and it succeeded.
- Validated the modified workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/vercel-preview-deploy.yml'); puts 'yaml ok'"` which returned `yaml ok`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c7d30668883269eaca271002e4928)