### PR TITLE
feat: preview @waline/admin in Vercel PR deployments

### DIFF
--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -65,7 +65,7 @@ jobs:
               deployment_id: deployment.data.id,
               state: 'in_progress',
               log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              description: 'Building API and client before Vercel deployment...',
+              description: 'Building API, client, and admin before Vercel deployment...',
             });
 
             core.setOutput('id', deployment.data.id);
@@ -77,7 +77,7 @@ jobs:
             const marker = '<!-- waline-vercel-preview -->';
             const prNumber = context.payload.pull_request.number;
             const commit = context.payload.pull_request.head.sha;
-            const body = `${marker}\n### Vercel Preview\n\n⏳ Building \`@waline/api\` and \`@waline/client\`, then deploying to Vercel...\n\n- PR: #${prNumber}\n- Commit: ${commit}\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+            const body = `${marker}\n### Vercel Preview\n\n⏳ Building \`@waline/api\`, \`@waline/client\`, and \`@waline/admin\`, then deploying to Vercel...\n\n- PR: #${prNumber}\n- Commit: ${commit}\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -95,9 +95,11 @@ jobs:
         run: |
           pnpm api:build
           pnpm client:build
-          rm -rf packages/server/__tests__/fixtures/vercel/client
-          mkdir -p packages/server/__tests__/fixtures/vercel/client
+          pnpm admin:build
+          rm -rf packages/server/__tests__/fixtures/vercel/client packages/server/__tests__/fixtures/vercel/admin
+          mkdir -p packages/server/__tests__/fixtures/vercel/client packages/server/__tests__/fixtures/vercel/admin
           cp packages/client/dist/waline.js packages/client/dist/waline.css packages/server/__tests__/fixtures/vercel/client/
+          cp packages/admin/dist/admin.js packages/server/__tests__/fixtures/vercel/admin/
           sed -i \
             -e 's#__WALINE_PREVIEW_PR__#${{ github.event.pull_request.number }}#g' \
             -e 's#__WALINE_PREVIEW_PR_URL__#${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }}#g' \

--- a/packages/server/__tests__/fixtures/vercel/vercel.json
+++ b/packages/server/__tests__/fixtures/vercel/vercel.json
@@ -4,7 +4,8 @@
     "silent": true
   },
   "env": {
-    "NODE_OPTIONS": "--experimental-require-module"
+    "NODE_OPTIONS": "--experimental-require-module",
+    "WALINE_ADMIN_MODULE_ASSET_URL": "/admin/admin.js"
   },
   "builds": [
     {
@@ -13,6 +14,10 @@
     },
     {
       "src": "client/**",
+      "use": "@vercel/static"
+    },
+    {
+      "src": "admin/**",
       "use": "@vercel/static"
     },
     {
@@ -36,6 +41,10 @@
     {
       "source": "/client/(.*)",
       "destination": "/client/$1"
+    },
+    {
+      "source": "/admin/(.*)",
+      "destination": "/admin/$1"
     },
     {
       "source": "/(.*)",

--- a/packages/server/__tests__/vercel.spec.js
+++ b/packages/server/__tests__/vercel.spec.js
@@ -146,6 +146,16 @@ describe('vercel runtime', () => {
     });
   }, 70_000);
 
+  it('should reference the preview admin bundle in the dashboard', async () => {
+    await waitForVercel();
+
+    const response = await fetch(`${getVercelUrl()}/ui`);
+    const body = await response.text();
+
+    expect(response.ok).toBe(true);
+    expect(body).toContain('<script src="/admin/admin.js"></script>');
+  }, 70_000);
+
   it('should publish and fetch a comment through vercel dev', async () => {
     await waitForVercel();
 


### PR DESCRIPTION
### Motivation

- Enable real-time PR preview for the @waline/admin frontend so dashboard changes can be inspected in Vercel preview deployments.
- Mirror the existing @waline/client preview flow by compiling and shipping the admin bundle into the Vercel fixture and wiring the runtime to use it.

### Description

- Build `@waline/admin` during the preview artifact step and copy `packages/admin/dist/admin.js` into the Vercel fixture under `admin/` so it can be served as a static asset.
- Add `WALINE_ADMIN_MODULE_ASSET_URL` to the Vercel fixture `vercel.json` (set to `/admin/admin.js`) and configure `admin/**` as a static build with a `/admin/(.*)` rewrite.
- Update the Vercel preview workflow messaging to include `@waline/admin` and extend the build step to run `pnpm admin:build` before packaging the fixture.
- Add a runtime test that fetches `/ui` from the Vercel fixture and asserts the dashboard references the preview admin bundle via `<script src="/admin/admin.js"></script>`.

### Testing

- `node -e "JSON.parse(require('fs').readFileSync('packages/server/__tests__/fixtures/vercel/vercel.json','utf8')); console.log('vercel.json ok')"` succeeded and validated the fixture JSON.
- `git diff --check` passed with no whitespace or parse errors found in the modified files.
- Attempting `pnpm admin:build && pnpm client:build && pnpm --filter @waline/vercel test -- vercel.spec.js` could not complete in this environment because the workspace requires Node.js `^24.17.0` while the current runtime is `v24.15.0`.
- Running `COREPACK_ENABLE_PROJECT_SPEC=0 pnpm admin:build` after bypassing the Node check failed because required build-time dependencies (e.g. `@vitejs/plugin-react`, `vite-plugin-css-injected-by-js`, `vite-plugin-svgr`) are not installed in the container, so full build+test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4df6da363c832684c648554f72a76e)