### PR TITLE
fix(vercel): replace require(esm) with dynamic import()

### DIFF
--- a/packages/server/__tests__/markdown.spec.js
+++ b/packages/server/__tests__/markdown.spec.js
@@ -1,10 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { getMarkdownParser } from '../src/service/markdown/index';
 
-const parser = getMarkdownParser();
-
 describe('markdown parser', () => {
+  let parser;
+
+  // oxlint-disable-next-line vitest/no-hooks
+  beforeAll(async () => {
+    parser = await getMarkdownParser();
+  });
   it('should render basic markdown', () => {
     const result = parser('**bold** and *italic* and `code`');
 

--- a/packages/server/src/controller/comment.js
+++ b/packages/server/src/controller/comment.js
@@ -52,7 +52,7 @@ const formatCmt = async (
     comment.addr = await think.ip2region(ip, { depth: isAdmin ? 3 : 1 });
   }
 
-  comment.comment = markdownParser(comment.comment);
+  comment.comment = (await markdownParser)(comment.comment);
   comment.like = Number(comment.like) || 0;
 
   // compat sql storage return number flag to string

--- a/packages/server/src/controller/comment/rss.js
+++ b/packages/server/src/controller/comment/rss.js
@@ -120,12 +120,13 @@ module.exports = class extends BaseRest {
       );
     }
 
+    const md = await markdownParser;
     const items = comments.map((comment) => {
       const user = users.find(({ objectId }) => objectId === comment.user_id);
       const nick = user?.display_name || comment.nick || 'Anonymous';
       const commentUrl = buildAbsoluteUrl(siteUrl, comment.url);
       const itemLink = commentUrl ? `${commentUrl}#${comment.objectId}` : '';
-      const description = markdownParser(comment.comment || '');
+      const description = md(comment.comment || '');
 
       return {
         title: `${nick} commented${comment.url ? ` on ${comment.url}` : ''}`,

--- a/packages/server/src/service/markdown/index.js
+++ b/packages/server/src/service/markdown/index.js
@@ -1,14 +1,10 @@
-const { katex: katexPlugin } = require('@mdit/plugin-katex');
-const { sub: subPlugin } = require('@mdit/plugin-sub');
-const { createMathjaxInstance, mathjax: mathjaxPlugin } = require('@mdit/plugin-mathjax/sync');
-const { sup: supPlugin } = require('@mdit/plugin-sup');
 const MarkdownIt = require('markdown-it');
 const emojiPlugin = require('markdown-it-emoji');
 
 const { resolveHighlighter } = require('./highlight.js');
 const { sanitize } = require('./xss.js');
 
-const getMarkdownParser = (markdown = {}) => {
+const getMarkdownParser = async (markdown = {}) => {
   const { config = {}, plugin = {} } = markdown;
 
   // markdown-it instance
@@ -39,21 +35,26 @@ const getMarkdownParser = (markdown = {}) => {
 
   // parse sub
   if (sub !== false) {
-    markdownIt.use(subPlugin);
+    const { sub } = await import('@mdit/plugin-sub');
+    markdownIt.use(sub);
   }
 
   // parse sup
   if (sup !== false) {
-    markdownIt.use(supPlugin);
+    const { sup } = await import('@mdit/plugin-sup');
+    markdownIt.use(sup);
   }
 
   // parse tex
   if (tex === 'katex') {
+    const { katex: katexPlugin } = await import('@mdit/plugin-katex');
     markdownIt.use(katexPlugin, {
       ...katex,
       output: 'mathml',
     });
   } else if (tex !== false) {
+    const { createMathjaxInstance, mathjax: mathjaxPlugin } =
+      await import('@mdit/plugin-mathjax/sync');
     const mathjaxInstance = createMathjaxInstance({ output: 'svg', mathjax });
     markdownIt.use(mathjaxPlugin, mathjaxInstance);
   }


### PR DESCRIPTION
Fixes #3706.

`require(esm)` blows up on Vercel Lambda because they disable `--experimental-require-module`. This swaps the four top-level `require()` calls for lazy `await import()`, which is how you normally load ESM from CJS.

`import()` does not need any flags. It works on basically every Node version still alive. Node caches the result after the first call, so `markdownIt.render()` stays synchronous after cold start. No per-request cost.

Would be grateful for a review when you find a moment.

cc: @lizheming 