### PR TITLE
fix(admin, server): lowercase email before hashing for libravatar

### DIFF
--- a/packages/admin/src/pages/manage-comments/utils.js
+++ b/packages/admin/src/pages/manage-comments/utils.js
@@ -5,7 +5,8 @@ export const buildAvatar = (email = '', avatar = '') => {
     return avatar;
   }
 
-  const normalizedEmail = typeof email === 'string' ? email : '';
+  // Libravatar/Gravatar spec requires normalising the email (trim + lowercase) before hashing
+  const normalizedEmail = typeof email === 'string' ? email.trim().toLowerCase() : '';
 
   return `https://seccdn.libravatar.org/avatar/${md5(normalizedEmail)}`;
 };

--- a/packages/server/src/service/avatar.js
+++ b/packages/server/src/service/avatar.js
@@ -10,6 +10,8 @@ const env = new nunjucks.Environment();
 env.addFilter('md5', (str) => helper.md5(str));
 env.addFilter('sha256', (str) => crypto.createHash('sha256').update(str).digest('hex'));
 
+// Normalise the email (trim + lowercase) in the template via nunjucks built-in
+// filters before hashing, per the libravatar/gravatar spec.
 const DEFAULT_GRAVATAR_STR = `{%- set numExp = r/^[0-9]+$/g -%}
 {%- set qqMailExp = r/^[0-9]+@qq.com$/ig -%}
 {%- if numExp.test(nick) -%}
@@ -17,7 +19,7 @@ const DEFAULT_GRAVATAR_STR = `{%- set numExp = r/^[0-9]+$/g -%}
 {%- elif qqMailExp.test(mail) -%}
   https://q1.qlogo.cn/g?b=qq&nk={{mail|replace('@qq.com', '')}}&s=100
 {%- else -%}
-  https://seccdn.libravatar.org/avatar/{{mail|md5}}
+  https://seccdn.libravatar.org/avatar/{{mail | trim | lower | md5}}
 {%- endif -%}`;
 
 module.exports = class extends think.Service {


### PR DESCRIPTION
Libravatar (as well as Gravatar) requires the email address to be converted to lowercase before being hashed for avatar URL: https://wiki.libravatar.org/api/

This is not implemented in Waline, meaning that if a commenter used uppercase in email address, the avatar for the user won't be displayed correctly.

Fix by adding `toLowerCase` before hashing email address.