### PR TITLE
fix(server): send Discord webhook payload as JSON

### DIFF
--- a/packages/server/__tests__/notify.spec.js
+++ b/packages/server/__tests__/notify.spec.js
@@ -1,0 +1,63 @@
+// oxlint-disable vitest/no-hooks react/no-this-in-sfc
+import { createRequire } from 'node:module';
+
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const originalThinkConfig = globalThis.think.config;
+const originalThinkService = globalThis.think.Service;
+
+globalThis.think.Service = function Service(controller) {
+  this.controller = controller;
+};
+globalThis.think.config = (name) => (name === 'DiscordTemplate' ? 'New comment' : undefined);
+
+process.env.DISCORD_WEBHOOK = 'https://discord.example/webhook';
+process.env.SITE_NAME = 'Waline Test';
+process.env.SITE_URL = 'https://example.com';
+
+const NotifyService = require('../src/service/notify.js');
+
+describe('discord notification', () => {
+  afterAll(() => {
+    vi.unstubAllGlobals();
+    delete process.env.DISCORD_WEBHOOK;
+    delete process.env.SITE_NAME;
+    delete process.env.SITE_URL;
+    globalThis.think.config = originalThinkConfig;
+    globalThis.think.Service = originalThinkService;
+  });
+
+  it('sends webhook content as JSON', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      statusText: 'No Content',
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const service = new NotifyService({
+      locale: (template) => template,
+    });
+    const result = await service.discord(
+      {
+        title: 'New comment title',
+        content: 'Ignored content',
+      },
+      {
+        objectId: 1,
+        url: '/posts/test/',
+      },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith('https://discord.example/webhook', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        content: 'New comment title\nNew comment',
+      }),
+    });
+    expect(result).toBe('No Content');
+  });
+});

--- a/packages/server/src/service/notify.js
+++ b/packages/server/src/service/notify.js
@@ -399,14 +399,14 @@ module.exports = class NotifyService extends think.Service {
       data,
     );
 
-    const form = new FormData();
-
-    form.append('content', `${title}\n${content}`);
-
     return fetch(DISCORD_WEBHOOK, {
       method: 'POST',
-      headers: form.getHeaders(),
-      body: form,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        content: `${title}\n${content}`,
+      }),
     }).then((resp) => resp.statusText);
     // Expected return value: No Content
     // Since Discord doesn't return any response body on success, we just return the status text.


### PR DESCRIPTION
## Summary

- send Discord webhook content as an `application/json` payload
- remove the unnecessary multipart `FormData` request
- add a focused unit test for the Discord request URL, headers, body, and return value

## Root cause

The Discord webhook implementation sent `content` as a regular `multipart/form-data` field. Discord accepts ordinary webhook messages as JSON; multipart requests use `payload_json` for non-file parameters. As a result, the current request may complete without creating a visible Discord message.

The new request sends the existing title and rendered template content as:

```json
{
  "content": "<title>\n<content>"
}
```

## Impact

Discord comment notifications are delivered using Discord's documented JSON message payload. The template output and notification fallback behavior remain unchanged.

## Verification

- `pnpm run lint`
- `pnpm run build`
- `CI=1 pnpm run test`
- `pnpm run docs:build`
- `git diff --check`
- packed the modified `@waline/vercel` package and deployed it to Vercel
- submitted a real comment and confirmed that the Discord notification was delivered

Fixes #3770