### PR TITLE
chore(deps): update think-model-postgresql to ^1.1.10

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -51,7 +51,7 @@
     "think-model": "^1.5.4",
     "think-model-mysql": "^1.1.7",
     "think-model-mysql2": "^2.0.0",
-    "think-model-postgresql": "1.1.7",
+    "think-model-postgresql": "^1.1.10",
     "think-model-sqlite": "^2.0.1",
     "think-mongo": "^2.2.1",
     "think-router-rest": "^1.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,8 +373,8 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@22.20.1)
       think-model-postgresql:
-        specifier: 1.1.7
-        version: 1.1.7
+        specifier: ^1.1.10
+        version: 1.1.10
       think-model-sqlite:
         specifier: ^2.0.1
         version: 2.0.1
@@ -7230,8 +7230,8 @@ packages:
   think-model-mysql@1.1.7:
     resolution: {integrity: sha512-HQN66b7RcIzKPnfS2xfDAPlgoy5aFaw4oOMBgHzraMzUco5R/CxoyWrbrL+C+zbKTjstY5UMo5GCJFPBqzJOng==}
 
-  think-model-postgresql@1.1.7:
-    resolution: {integrity: sha512-ccF5iSnVNlG641hV2KwQCOl1w0FpbHSv9E8h0djWAZdiVLujfs7G8TQ3kp3xDZx0KzM6zfzJh2RWIsbC1SG9HQ==}
+  think-model-postgresql@1.1.10:
+    resolution: {integrity: sha512-mzdNREn3JBRaqbmCa9qsRAF2/oUiBBIlGJiw5fiAdVtVHqbY34bvPdMTyFyE6jfMR3ha1hOsP92HP5Ff9X36cA==}
 
   think-model-sqlite@2.0.1:
     resolution: {integrity: sha512-F/6c/7sjpC6sLem4+VqJfrCMwveh051dzCVG5NUWUcuWdc9VRm92ATpxjqNWrliatIGeOhUTotbuMwPPUICZAA==}
@@ -15286,7 +15286,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  think-model-postgresql@1.1.7:
+  think-model-postgresql@1.1.10:
     dependencies:
       pg: 8.22.0
       think-debounce: 1.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,6 +29,7 @@ minimumReleaseAgeExclude:
   - oxlint
   - oxlint-tsgolint
   - tsdown
+  - think-model-postgresql@1.1.10
   - vercel
   - vitest
   - vue


### PR DESCRIPTION
fix https://github.com/walinejs/waline/issues/3645

## Summary

- update `think-model-postgresql` from the fixed `1.1.7` version to `^1.1.10`
- restore automatic patch and minor version tracking now that the earlier compatibility issue has been resolved
- update the lockfile to `1.1.10` and allow this newly published version through the repository's minimum release age policy

## Context

`think-model-postgresql@1.1.10` includes the backslash escaping fix from thinkjs/thinkjs#1775, resolving walinejs/waline#3645. PostgreSQL comments containing LaTeX commands such as `\frac` are now stored without being converted to control characters.

## Validation

- frozen lockfile installation completed successfully
- confirmed the installed server dependency resolves to `think-model-postgresql@1.1.10`
- server test suite: 5 files passed, 33 tests passed
- formatting checks passed
