### PR TITLE
refactor(server): unify storage ordering

### DIFF
--- a/packages/server/__tests__/storage-order.spec.js
+++ b/packages/server/__tests__/storage-order.spec.js
@@ -1,0 +1,60 @@
+import { createRequire } from 'node:module';
+
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+  compareByOrder,
+  normalizeOrder,
+  toOrderString,
+  toSqlOrder,
+} = require('../src/service/storage/order.js');
+
+describe('storage order', () => {
+  const order = [
+    { field: 'sticky', direction: 'desc', nulls: 'last' },
+    { field: 'insertedAt', direction: 'desc' },
+    { field: 'objectId', direction: 'desc' },
+  ];
+
+  it('normalizes fields and keeps explicit null placement', () => {
+    expect(normalizeOrder(order, undefined, (field) => field.toLowerCase())).toStrictEqual([
+      { field: 'sticky', direction: 'desc', nulls: 'last' },
+      { field: 'insertedat', direction: 'desc', nulls: undefined },
+      { field: 'objectid', direction: 'desc', nulls: undefined },
+    ]);
+  });
+
+  it('builds SQL and document-store order formats', () => {
+    const normalized = normalizeOrder(order);
+
+    expect(toSqlOrder(normalized)).toStrictEqual({
+      sticky: 'DESC',
+      insertedAt: 'DESC',
+      objectId: 'DESC',
+    });
+    expect(toSqlOrder(normalized, { nulls: true }).sticky).toBe('DESC NULLS LAST');
+    expect(toOrderString(normalized)).toBe('sticky DESC, insertedAt DESC, objectId DESC');
+  });
+
+  it('sorts null sticky values last and uses stable tie breakers', () => {
+    const comments = [
+      { id: 1, insertedAt: 2, sticky: null },
+      { id: 2, insertedAt: 2, sticky: 1 },
+      { id: 3, insertedAt: 2, sticky: null },
+    ];
+    const normalized = normalizeOrder([
+      { field: 'sticky', direction: 'desc', nulls: 'last' },
+      { field: 'insertedAt', direction: 'desc' },
+      { field: 'id', direction: 'desc' },
+    ]);
+
+    expect(comments.sort(compareByOrder(normalized)).map(({ id }) => id)).toStrictEqual([2, 3, 1]);
+  });
+
+  it('keeps the legacy desc option working', () => {
+    expect(normalizeOrder(undefined, 'insertedAt')).toStrictEqual([
+      { field: 'insertedAt', direction: 'desc', nulls: undefined },
+    ]);
+  });
+});

--- a/packages/server/__tests__/storage-order.spec.js
+++ b/packages/server/__tests__/storage-order.spec.js
@@ -52,6 +52,30 @@ describe('storage order', () => {
     expect(comments.sort(compareByOrder(normalized)).map(({ id }) => id)).toStrictEqual([2, 3, 1]);
   });
 
+  it('supports storage-specific value coercion', () => {
+    const comments = [
+      { id: 1, insertedAt: 'Tue Dec 31 2024 12:00:00 GMT+0000' },
+      { id: 2, insertedAt: 'Mon Jan 06 2025 12:00:00 GMT+0000' },
+    ];
+    const normalized = normalizeOrder([{ field: 'insertedAt', direction: 'desc' }]);
+
+    expect(
+      comments
+        .sort(compareByOrder(normalized, (_field, value) => new Date(value).getTime()))
+        .map(({ id }) => id),
+    ).toStrictEqual([2, 1]);
+  });
+
+  it('maps the storage-neutral objectId field to a physical ID field', () => {
+    const normalized = normalizeOrder(
+      [{ field: 'objectId', direction: 'desc' }],
+      undefined,
+      () => '_id',
+    );
+
+    expect(normalized.at(-1)?.field).toBe('_id');
+  });
+
   it('keeps the legacy desc option working', () => {
     expect(normalizeOrder(undefined, 'insertedAt')).toStrictEqual([
       { field: 'insertedAt', direction: 'desc', nulls: undefined },

--- a/packages/server/src/service/storage/base.js
+++ b/packages/server/src/service/storage/base.js
@@ -6,7 +6,7 @@ module.exports = class extends think.Service {
     this.tableName = tableName;
   }
 
-  async select(where, { desc, limit, offset, field } = {}) {
+  async select(where, { desc, field, limit, offset, order } = {}) {
     //to be implemented
   }
 

--- a/packages/server/src/service/storage/cloudbase.js
+++ b/packages/server/src/service/storage/cloudbase.js
@@ -134,7 +134,9 @@ module.exports = class extends Base {
     let instance = await this.collection(this.tableName);
 
     instance = this.where(instance, where);
-    const normalizedOrder = normalizeOrder(order, desc);
+    const normalizedOrder = normalizeOrder(order, desc, (orderField) =>
+      orderField === 'objectId' ? '_id' : orderField,
+    );
 
     for (const { field: orderField, direction } of normalizedOrder) {
       instance = instance.orderBy(orderField, direction);

--- a/packages/server/src/service/storage/cloudbase.js
+++ b/packages/server/src/service/storage/cloudbase.js
@@ -1,6 +1,7 @@
 const cloudbase = require('@cloudbase/node-sdk');
 
 const Base = require('./base.js');
+const { normalizeOrder } = require('./order.js');
 
 const { TCB_ENV, TCB_ID, TCB_KEY } = process.env;
 const app = cloudbase.init({
@@ -129,12 +130,14 @@ module.exports = class extends Base {
     return instance[method](_[where._complex._logic](...filters));
   }
 
-  async _select(where, { desc, limit, offset, field } = {}) {
+  async _select(where, { desc, field, limit, offset, order } = {}) {
     let instance = await this.collection(this.tableName);
 
     instance = this.where(instance, where);
-    if (desc) {
-      instance = instance.orderBy(desc, 'desc');
+    const normalizedOrder = normalizeOrder(order, desc);
+
+    for (const { field: orderField, direction } of normalizedOrder) {
+      instance = instance.orderBy(orderField, direction);
     }
 
     if (limit) {

--- a/packages/server/src/service/storage/github.js
+++ b/packages/server/src/service/storage/github.js
@@ -3,6 +3,7 @@ const path = require('node:path');
 const { parseString, writeToString } = require('fast-csv');
 
 const Base = require('./base.js');
+const { compareByOrder, normalizeOrder } = require('./order.js');
 
 const CSV_HEADERS = {
   Comment: [
@@ -271,24 +272,19 @@ module.exports = class GithubStorage extends Base {
     return data.filter((item) => logicFn.call(filters, (filter) => filter.every((fn) => fn(item))));
   }
 
-  async select(where, { desc, limit, offset, field } = {}) {
+  async select(where, { desc, field, limit, offset, order } = {}) {
     const instance = await this.collection(this.tableName);
     let data = this.where(instance, where);
 
-    if (desc) {
-      data.sort((a, b) => {
-        if (['insertedAt', 'createdAt', 'updatedAt'].includes(desc)) {
-          const aTime = new Date(a[desc]).getTime();
-          const bTime = new Date(b[desc]).getTime();
+    const normalizedOrder = normalizeOrder(order, desc, (orderField) =>
+      orderField === 'objectId' ? 'id' : orderField,
+    );
 
-          return bTime - aTime;
-        }
-
-        return a[desc] - b[desc];
-      });
+    if (normalizedOrder.length > 0) {
+      data.sort(compareByOrder(normalizedOrder));
     }
 
-    data = data.slice(limit ?? 0, offset ?? data.length);
+    data = data.slice(offset ?? 0, limit ? (offset ?? 0) + limit : undefined);
     if (field) {
       field.push('id');
       const fieldObj = {};

--- a/packages/server/src/service/storage/github.js
+++ b/packages/server/src/service/storage/github.js
@@ -5,6 +5,8 @@ const { parseString, writeToString } = require('fast-csv');
 const Base = require('./base.js');
 const { compareByOrder, normalizeOrder } = require('./order.js');
 
+const DATE_FIELDS = new Set(['insertedAt', 'createdAt', 'updatedAt']);
+
 const CSV_HEADERS = {
   Comment: [
     'objectId',
@@ -281,7 +283,11 @@ module.exports = class GithubStorage extends Base {
     );
 
     if (normalizedOrder.length > 0) {
-      data.sort(compareByOrder(normalizedOrder));
+      data.sort(
+        compareByOrder(normalizedOrder, (field, value) =>
+          DATE_FIELDS.has(field) ? new Date(value).getTime() : value,
+        ),
+      );
     }
 
     data = data.slice(offset ?? 0, limit ? (offset ?? 0) + limit : undefined);

--- a/packages/server/src/service/storage/leancloud.js
+++ b/packages/server/src/service/storage/leancloud.js
@@ -1,6 +1,7 @@
 const AV = require('leancloud-storage');
 
 const Base = require('./base.js');
+const { normalizeOrder } = require('./order.js');
 
 const { LEAN_ID, LEAN_KEY, LEAN_MASTER_KEY, LEAN_SERVER } = process.env;
 
@@ -104,12 +105,16 @@ module.exports = class extends Base {
     return AV.Query[where._complex._logic](...filters);
   }
 
-  async _select(where, { desc, limit, offset, field } = {}) {
+  async _select(where, { desc, field, limit, offset, order } = {}) {
     const instance = this.where(this.tableName, where);
 
-    if (desc) {
-      instance.descending(desc);
-    }
+    const normalizedOrder = normalizeOrder(order, desc);
+
+    normalizedOrder.forEach(({ field: orderField, direction }, index) => {
+      const method = `${index === 0 ? '' : 'add'}${direction === 'desc' ? 'Descending' : 'Ascending'}`;
+
+      instance[method.charAt(0).toLowerCase() + method.slice(1)](orderField);
+    });
 
     if (limit) {
       instance.limit(limit);

--- a/packages/server/src/service/storage/mongodb.js
+++ b/packages/server/src/service/storage/mongodb.js
@@ -1,6 +1,7 @@
 const { ObjectID: ObjectId } = require('think-mongo/lib/model');
 
 const Base = require('./base.js');
+const { normalizeOrder, toOrderString } = require('./order.js');
 
 module.exports = class extends Base {
   parseWhere(where) {
@@ -110,12 +111,16 @@ module.exports = class extends Base {
     });
   }
 
-  async select(where, { desc, limit, offset, field } = {}) {
+  async select(where, { desc, field, limit, offset, order } = {}) {
     const instance = this.mongo(this.tableName);
 
     this.where(instance, where);
-    if (desc) {
-      instance.order(`${desc} DESC`);
+    const normalizedOrder = normalizeOrder(order, desc, (field) =>
+      field === 'objectId' ? '_id' : field,
+    );
+
+    if (normalizedOrder.length > 0) {
+      instance.order(toOrderString(normalizedOrder));
     }
 
     if (limit || offset) {

--- a/packages/server/src/service/storage/mysql.js
+++ b/packages/server/src/service/storage/mysql.js
@@ -1,6 +1,19 @@
 const Base = require('./base.js');
+const { normalizeOrder, toSqlOrder } = require('./order.js');
 
 module.exports = class extends Base {
+  mapOrderField(field) {
+    return field === 'objectId' ? 'id' : field;
+  }
+
+  getOrder(order, desc) {
+    return normalizeOrder(order, desc, (field) => this.mapOrderField(field));
+  }
+
+  getSqlOrder(order) {
+    return toSqlOrder(order);
+  }
+
   parseWhere(filter) {
     const where = {};
 
@@ -40,12 +53,14 @@ module.exports = class extends Base {
     return where;
   }
 
-  async select(where, { desc, limit, offset, field } = {}) {
+  async select(where, { desc, field, limit, offset, order } = {}) {
     const instance = this.model(this.tableName);
 
     instance.where(this.parseWhere(where));
-    if (desc) {
-      instance.order({ [desc]: 'DESC' });
+    const normalizedOrder = this.getOrder(order, desc);
+
+    if (normalizedOrder.length > 0) {
+      instance.order(this.getSqlOrder(normalizedOrder));
     }
 
     if (limit || offset) {

--- a/packages/server/src/service/storage/order.js
+++ b/packages/server/src/service/storage/order.js
@@ -37,29 +37,34 @@ const toSqlOrder = (order, { nulls = false } = {}) =>
 const toOrderString = (order) =>
   order.map(({ field, direction }) => `${field} ${direction.toUpperCase()}`).join(', ');
 
-const compareByOrder = (order) => (left, right) => {
-  for (const { field, direction, nulls } of order) {
-    const leftValue = left[field];
-    const rightValue = right[field];
-    const leftIsNull = leftValue == null;
-    const rightIsNull = rightValue == null;
+const compareByOrder =
+  (order, mapValue = (_field, value) => value) =>
+  (left, right) => {
+    for (const { field, direction, nulls } of order) {
+      const leftRawValue = left[field];
+      const rightRawValue = right[field];
+      const leftIsNull = leftRawValue == null;
+      const rightIsNull = rightRawValue == null;
 
-    if (leftIsNull || rightIsNull) {
-      if (leftIsNull && rightIsNull) continue;
+      if (leftIsNull || rightIsNull) {
+        if (leftIsNull && rightIsNull) continue;
 
-      const nullResult = nulls === 'first' ? -1 : 1;
+        const nullResult = nulls === 'first' ? -1 : 1;
 
-      return leftIsNull ? nullResult : -nullResult;
+        return leftIsNull ? nullResult : -nullResult;
+      }
+
+      const leftValue = mapValue(field, leftRawValue);
+      const rightValue = mapValue(field, rightRawValue);
+
+      if (leftValue === rightValue) continue;
+
+      const result = leftValue > rightValue ? 1 : -1;
+
+      return direction === 'desc' ? -result : result;
     }
 
-    if (leftValue === rightValue) continue;
-
-    const result = leftValue > rightValue ? 1 : -1;
-
-    return direction === 'desc' ? -result : result;
-  }
-
-  return 0;
-};
+    return 0;
+  };
 
 module.exports = { compareByOrder, normalizeOrder, toOrderString, toSqlOrder };

--- a/packages/server/src/service/storage/order.js
+++ b/packages/server/src/service/storage/order.js
@@ -1,0 +1,65 @@
+const ORDER_DIRECTIONS = new Set(['asc', 'desc']);
+const NULL_ORDERS = new Set(['first', 'last']);
+
+const normalizeOrder = (order, desc, mapField = (field) => field) => {
+  const entries = order ?? (desc ? [{ field: desc, direction: 'desc' }] : []);
+
+  return entries.map(({ field, direction = 'asc', nulls }) => {
+    const normalizedDirection = direction.toLowerCase();
+    const normalizedNulls = nulls?.toLowerCase();
+
+    if (!ORDER_DIRECTIONS.has(normalizedDirection)) {
+      throw new TypeError(`Invalid order direction: ${direction}`);
+    }
+
+    if (normalizedNulls && !NULL_ORDERS.has(normalizedNulls)) {
+      throw new TypeError(`Invalid null order: ${nulls}`);
+    }
+
+    return {
+      field: mapField(field),
+      direction: normalizedDirection,
+      nulls: normalizedNulls,
+    };
+  });
+};
+
+const toSqlOrder = (order, { nulls = false } = {}) =>
+  Object.fromEntries(
+    order.map(({ field, direction, nulls: nullOrder }) => [
+      field,
+      [direction.toUpperCase(), nulls && nullOrder ? `NULLS ${nullOrder.toUpperCase()}` : '']
+        .filter(Boolean)
+        .join(' '),
+    ]),
+  );
+
+const toOrderString = (order) =>
+  order.map(({ field, direction }) => `${field} ${direction.toUpperCase()}`).join(', ');
+
+const compareByOrder = (order) => (left, right) => {
+  for (const { field, direction, nulls } of order) {
+    const leftValue = left[field];
+    const rightValue = right[field];
+    const leftIsNull = leftValue == null;
+    const rightIsNull = rightValue == null;
+
+    if (leftIsNull || rightIsNull) {
+      if (leftIsNull && rightIsNull) continue;
+
+      const nullResult = nulls === 'first' ? -1 : 1;
+
+      return leftIsNull ? nullResult : -nullResult;
+    }
+
+    if (leftValue === rightValue) continue;
+
+    const result = leftValue > rightValue ? 1 : -1;
+
+    return direction === 'desc' ? -result : result;
+  }
+
+  return 0;
+};
+
+module.exports = { compareByOrder, normalizeOrder, toOrderString, toSqlOrder };

--- a/packages/server/src/service/storage/postgresql.js
+++ b/packages/server/src/service/storage/postgresql.js
@@ -1,4 +1,5 @@
 const MySQL = require('./mysql.js');
+const { toSqlOrder } = require('./order.js');
 
 const mapKeys = ({ insertedat, createdat, updatedat, ...item }) => {
   const mapFields = {
@@ -18,6 +19,14 @@ const mapKeys = ({ insertedat, createdat, updatedat, ...item }) => {
   return item;
 };
 module.exports = class extends MySQL {
+  mapOrderField(field) {
+    return super.mapOrderField(field).toLowerCase();
+  }
+
+  getSqlOrder(order) {
+    return toSqlOrder(order, { nulls: true });
+  }
+
   model(tableName) {
     return super.model(tableName.toLowerCase());
   }
@@ -27,10 +36,6 @@ module.exports = class extends MySQL {
 
     for (const i in where) {
       lowerWhere[i.toLowerCase()] = where[i];
-    }
-
-    if (options?.desc) {
-      options.desc = options.desc.toLowerCase();
     }
 
     if (Array.isArray(options.field)) {


### PR DESCRIPTION
## What changed

- adds a structured, ordered storage `order` contract with explicit direction and null placement
- implements the contract for SQL, PostgreSQL, MongoDB, CloudBase, LeanCloud, and GitHub storage
- maps storage-neutral `objectId` to each backend's physical ID field
- preserves the legacy `desc` option
- fixes GitHub storage's reversed `slice(limit, offset)` pagination arguments

## Why

Database-level comment pagination needs the same sticky-first and deterministic ordering on every supported storage backend. PostgreSQL also needs explicit `NULLS LAST` for nullable `sticky` values; otherwise `sticky DESC` puts non-sticky rows first.

This is the prerequisite for the root-comment pagination fix for #3678. A follow-up PR will use this contract and add the controller-level pagination.

## Validation

- `pnpm vitest run packages/server/__tests__` — 37 tests passed
- `pnpm oxlint packages/server/src/service/storage packages/server/__tests__/storage-order.spec.js --deny-warnings`
- `pnpm oxfmt --check packages/server/src/service/storage packages/server/__tests__/storage-order.spec.js`
