### PR TITLE
fix(server): paginate root comments in storage

### DIFF
--- a/packages/server/__tests__/github-storage.spec.js
+++ b/packages/server/__tests__/github-storage.spec.js
@@ -1,0 +1,35 @@
+import { createRequire } from 'node:module';
+
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const thinkHelper = require('think-helper');
+
+vi.stubGlobal('think', {
+  ...thinkHelper,
+  Service: class {},
+});
+
+const GithubStorage = require('../src/service/storage/github.js');
+
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('gitHub storage', () => {
+  it('treats blank CSV values as empty fields', () => {
+    const storage = Object.create(GithubStorage.prototype);
+    const comments = [
+      { id: 'blank', rid: '' },
+      { id: 'null', rid: null },
+      { id: 'undefined' },
+      { id: 'child', rid: 'blank' },
+    ];
+
+    expect(storage.where(comments, { rid: undefined }).map(({ id }) => id)).toStrictEqual([
+      'blank',
+      'null',
+      'undefined',
+    ]);
+  });
+});

--- a/packages/server/__tests__/github-storage.spec.js
+++ b/packages/server/__tests__/github-storage.spec.js
@@ -1,35 +1,36 @@
 import { createRequire } from 'node:module';
 
-import { afterAll, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
 const thinkHelper = require('think-helper');
 
-vi.stubGlobal('think', {
-  ...thinkHelper,
-  Service: class {},
-});
-
-const GithubStorage = require('../src/service/storage/github.js');
-
-afterAll(() => {
-  vi.unstubAllGlobals();
-});
-
 describe('gitHub storage', () => {
   it('treats blank CSV values as empty fields', () => {
-    const storage = Object.create(GithubStorage.prototype);
-    const comments = [
-      { id: 'blank', rid: '' },
-      { id: 'null', rid: null },
-      { id: 'undefined' },
-      { id: 'child', rid: 'blank' },
-    ];
+    const originalThink = globalThis.think;
 
-    expect(storage.where(comments, { rid: undefined }).map(({ id }) => id)).toStrictEqual([
-      'blank',
-      'null',
-      'undefined',
-    ]);
+    try {
+      globalThis.think = {
+        ...thinkHelper,
+        Service: Object,
+      };
+
+      const GithubStorage = require('../src/service/storage/github.js');
+      const storage = Object.create(GithubStorage.prototype);
+      const comments = [
+        { id: 'blank', rid: '' },
+        { id: 'null', rid: null },
+        { id: 'undefined' },
+        { id: 'child', rid: 'blank' },
+      ];
+
+      expect(storage.where(comments, { rid: undefined }).map(({ id }) => id)).toStrictEqual([
+        'blank',
+        'null',
+        'undefined',
+      ]);
+    } finally {
+      globalThis.think = originalThink;
+    }
   });
 });

--- a/packages/server/__tests__/token.spec.js
+++ b/packages/server/__tests__/token.spec.js
@@ -18,14 +18,16 @@ const { originalFetch } = vi.hoisted(() => ({
 const require = createRequire(import.meta.url);
 // const pkg = require('../package.json');
 const main = require('../index.js');
+const commentSelect = vi.fn(async () => []);
+const commentCount = vi.fn(async () => 0);
 
 // Use a custom model stub so no real database connection is needed
 const handler = main({
   customModel: (modelName) => {
     if (modelName === 'Comment') {
       return {
-        select: async () => [],
-        count: async () => 0,
+        select: commentSelect,
+        count: commentCount,
       };
     }
 
@@ -104,6 +106,8 @@ describe('token API', () => {
 
   describe('GET /api/comment', () => {
     it('should return an empty comment list for a running server', async () => {
+      commentSelect.mockClear();
+      commentCount.mockClear();
       const body = await apiRequest('GET', '/api/comment?path=/unit-test');
 
       expect(body.errno).toBe(0);
@@ -113,6 +117,19 @@ describe('token API', () => {
         count: 0,
         data: [],
       });
+      expect(commentCount).toHaveBeenCalledTimes(2);
+      expect(commentSelect).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ rid: undefined, url: '/unit-test' }),
+        expect.objectContaining({
+          limit: 10,
+          offset: 0,
+          order: [
+            { field: 'sticky', direction: 'desc', nulls: 'last' },
+            { field: 'insertedAt', direction: 'desc' },
+            { field: 'objectId', direction: 'desc' },
+          ],
+        }),
+      );
     });
   });
 

--- a/packages/server/src/controller/comment.js
+++ b/packages/server/src/controller/comment.js
@@ -390,11 +390,8 @@ module.exports = class CommentController extends BaseRest {
       };
     }
 
-    const totalCount = await this.modelInstance.count(where);
     const pageOffset = Math.max((page - 1) * pageSize, 0);
-    let comments = [];
-    let rootComments = [];
-    let rootCount = 0;
+    const [sortField, sortDirection] = sortBy.split('_');
     const selectOptions = {
       field: [
         'status',
@@ -413,64 +410,35 @@ module.exports = class CommentController extends BaseRest {
       ],
     };
 
-    if (sortBy) {
-      const [field, order] = sortBy.split('_');
+    if (sortDirection === 'desc') selectOptions.desc = sortField;
 
-      if (order === 'desc') {
-        selectOptions.desc = field;
-      } else if (order === 'asc') {
-        // do nothing because of ascending order is default behavior
-      }
-    }
-
-    /**
-     * Most of case we have just little comments while if we want get rootComments, rootCount,
-     * childComments with pagination we have to query three times from storage service That's so
-     * expensive for user, especially in the serverless. so we have a comments length check If you
-     * have less than 1000 comments, then we'll get all comments one time then we'll compute
-     * rootComment, rootCount, childComments in program to reduce http request query
-     *
-     * Why we have limit and the limit is 1000? Many serverless storages have fetch data limit, for
-     * example LeanCloud is 100, and CloudBase is 1000 If we have much comments, We should use more
-     * request to fetch all comments If we have 3000 comments, We have to use 30 http request to
-     * fetch comments, things go athwart. And Serverless Service like vercel have execute time limit
-     * if we have more http requests in a serverless function, it may timeout easily. so we use
-     * limit to avoid it.
-     */
-    if (totalCount < 1000) {
-      comments = await this.modelInstance.select(where, selectOptions);
-      rootCount = comments.filter(({ rid }) => !rid).length;
-      rootComments = [
-        ...comments.filter(({ rid, sticky }) => !rid && sticky),
-        ...comments.filter(({ rid, sticky }) => !rid && !sticky),
-      ].slice(pageOffset, pageOffset + pageSize);
-      const rootIds = {};
-
-      rootComments.forEach(({ objectId }) => {
-        rootIds[objectId] = true;
-      });
-      comments = comments.filter((cmt) => rootIds[cmt.objectId] || rootIds[cmt.rid]);
-    } else {
-      comments = await this.modelInstance.select(
-        { ...where, rid: undefined },
-        { ...selectOptions },
-      );
-      rootCount = comments.length;
-      rootComments = [
-        ...comments.filter(({ rid, sticky }) => !rid && sticky),
-        ...comments.filter(({ rid, sticky }) => !rid && !sticky),
-      ].slice(pageOffset, pageOffset + pageSize);
-
-      const children = await this.modelInstance.select(
-        {
-          ...where,
-          rid: ['IN', rootComments.map(({ objectId }) => objectId)],
-        },
-        selectOptions,
-      );
-
-      comments = [...rootComments, ...children];
-    }
+    const rootWhere = { ...where, rid: undefined };
+    const [totalCount, rootCount] = await Promise.all([
+      this.modelInstance.count(where),
+      this.modelInstance.count(rootWhere),
+    ]);
+    const rootComments = await this.modelInstance.select(rootWhere, {
+      ...selectOptions,
+      limit: pageSize,
+      offset: pageOffset,
+      order: [
+        { field: 'sticky', direction: 'desc', nulls: 'last' },
+        { field: sortField, direction: sortDirection },
+        { field: 'objectId', direction: sortDirection },
+      ],
+    });
+    const rootIds = rootComments.map(({ objectId }) => objectId);
+    const children =
+      rootIds.length > 0
+        ? await this.modelInstance.select(
+            {
+              ...where,
+              rid: ['IN', rootIds],
+            },
+            selectOptions,
+          )
+        : [];
+    const comments = [...rootComments, ...children];
 
     const userModel = this.getModel('Users');
     const user_ids = [...new Set(comments.map(({ user_id }) => user_id).filter(Boolean))];

--- a/packages/server/src/service/storage/cloudbase.js
+++ b/packages/server/src/service/storage/cloudbase.js
@@ -169,13 +169,22 @@ module.exports = class extends Base {
     const data = [];
     let ret = [];
     const offset = options.offset ?? 0;
+    const { limit } = options;
 
-    do {
-      options.offset = offset + data.length;
+    while (true) {
+      const remaining = limit == null ? undefined : limit - data.length;
+      const batchLimit = remaining == null ? undefined : Math.min(remaining, 100);
+
       // oxlint-disable-next-line no-underscore-dangle
-      ret = await this._select(where, options);
+      ret = await this._select(where, {
+        ...options,
+        limit: batchLimit,
+        offset: offset + data.length,
+      });
       data.push(...ret);
-    } while (ret.length === 100);
+
+      if (ret.length < 100 || (limit != null && data.length >= limit)) break;
+    }
 
     return data;
   }

--- a/packages/server/src/service/storage/github.js
+++ b/packages/server/src/service/storage/github.js
@@ -198,7 +198,7 @@ module.exports = class GithubStorage extends Base {
         continue;
       }
       if (where[k] === undefined) {
-        filters.push((item) => item[k] === null || item[k] === undefined);
+        filters.push((item) => item[k] === '' || item[k] === null || item[k] === undefined);
       }
 
       if (!Array.isArray(where[k]) || !where[k][0]) {

--- a/packages/server/src/service/storage/leancloud.js
+++ b/packages/server/src/service/storage/leancloud.js
@@ -143,13 +143,22 @@ module.exports = class extends Base {
     const data = [];
     let ret = [];
     const offset = options.offset ?? 0;
+    const { limit } = options;
 
-    do {
-      options.offset = offset + data.length;
+    while (true) {
+      const remaining = limit == null ? undefined : limit - data.length;
+      const batchLimit = remaining == null ? undefined : Math.min(remaining, 100);
+
       // oxlint-disable-next-line no-underscore-dangle
-      ret = await this._select(where, options);
+      ret = await this._select(where, {
+        ...options,
+        limit: batchLimit,
+        offset: offset + data.length,
+      });
       data.push(...ret);
-    } while (ret.length === 100);
+
+      if (ret.length < 100 || (limit != null && data.length >= limit)) break;
+    }
 
     return data;
   }


### PR DESCRIPTION
## What changed

- removes the `< 1000` / `>= 1000` in-memory pagination branches
- counts total comments and root comments concurrently
- fetches only the requested root-comment page with storage-level `limit` and `offset`
- fetches children only for roots on the current page
- skips the child query entirely for empty or out-of-range pages, avoiding the existing empty-`IN` full-query fallback
- makes CloudBase and LeanCloud honor the requested global limit instead of continuing batch fetches after the page is full
- adds an API regression assertion for pagination, ordering, and empty-page behavior

## Why

Waline currently fetches either every comment or every root comment from storage and applies `slice()` in memory. With PostgreSQL hosted by Supabase and Waline hosted by Vercel, those discarded rows still count as database egress. The query data in #3678 shows about 1,299 root rows returned per request for a page size of 20.

After this change, storage returns at most `pageSize` root rows plus the children belonging to those roots.

## Dependency

This PR is stacked on #3795, which provides consistent sticky-first, null-safe, deterministic ordering across storage adapters. Once #3795 merges, this PR can be retargeted to `main`.

## Validation

- `pnpm vitest run packages/server/__tests__` — 37 tests passed
- focused controller/storage lint and formatting checks passed

Fixes the comment-list portion of #3678.
