### PR TITLE
fix(server): aggregate comment counts in storage

### DIFF
--- a/packages/server/__tests__/comment-count.spec.js
+++ b/packages/server/__tests__/comment-count.spec.js
@@ -1,0 +1,90 @@
+// oxlint-disable vitest/no-hooks
+import http from 'node:http';
+import { createRequire } from 'node:module';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+process.env.SQLITE_PATH = `/tmp/test-waline-count-${process.pid}.sqlite`;
+process.env.JWT_TOKEN = 'test-jwt-secret';
+
+const require = createRequire(import.meta.url);
+const main = require('../index.js');
+const commentCount = vi.fn();
+const commentSelect = vi.fn();
+
+const handler = main({
+  customModel: (modelName) => {
+    if (modelName === 'Comment') {
+      return { count: commentCount, select: commentSelect };
+    }
+
+    if (modelName === 'Users') {
+      return { select: async () => [] };
+    }
+  },
+});
+
+describe('comment count API', () => {
+  let server;
+  let port;
+
+  beforeAll(async () => {
+    server = http.createServer(handler);
+    await new Promise((resolve) => {
+      server.listen(0, resolve);
+    });
+    ({ port } = server.address());
+  });
+
+  beforeEach(() => {
+    commentCount.mockReset();
+    commentSelect.mockReset();
+  });
+
+  afterAll(async () => {
+    delete process.env.SQLITE_PATH;
+    delete process.env.JWT_TOKEN;
+    await new Promise((resolve) => {
+      server.close(resolve);
+    });
+  });
+
+  const fetchCount = (urls) =>
+    fetch(
+      `http://localhost:${port}/api/comment?type=count&${urls
+        .map((url) => `url=${encodeURIComponent(url)}`)
+        .join('&')}`,
+    ).then((response) => response.json());
+
+  it('uses a scalar database count for one URL', async () => {
+    commentCount.mockResolvedValueOnce(7);
+
+    const body = await fetchCount(['/single']);
+
+    expect(body.data).toStrictEqual([7]);
+    expect(commentCount).toHaveBeenCalledExactlyOnceWith({
+      status: ['NOT IN', ['waiting', 'spam']],
+      url: ['IN', ['/single']],
+    });
+    expect(commentSelect).not.toHaveBeenCalled();
+  });
+
+  it('uses grouped counts for multiple URLs and fills missing values', async () => {
+    commentCount.mockResolvedValueOnce([
+      { url: '/first', count: 3 },
+      { url: '/third', count: 1 },
+    ]);
+
+    const body = await fetchCount(['/first', '/second', '/third']);
+
+    expect(body.data).toStrictEqual([3, 0, 1]);
+    expect(commentCount).toHaveBeenCalledExactlyOnceWith(
+      {
+        status: ['NOT IN', ['waiting', 'spam']],
+        url: ['IN', ['/first', '/second', '/third']],
+      },
+      { group: ['url'] },
+    );
+    expect(commentSelect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/__tests__/github-storage.spec.js
+++ b/packages/server/__tests__/github-storage.spec.js
@@ -33,4 +33,34 @@ describe('gitHub storage', () => {
       globalThis.think = originalThink;
     }
   });
+
+  it('returns grouped counts with their field values', async () => {
+    const originalThink = globalThis.think;
+
+    try {
+      globalThis.think = {
+        ...thinkHelper,
+        Service: Object,
+      };
+
+      const GithubStorage = require('../src/service/storage/github.js');
+      const storage = Object.create(GithubStorage.prototype);
+
+      storage.tableName = 'Comment';
+      storage.collection = async () => [
+        { id: 'first-1', url: '/first' },
+        { id: 'first-2', url: '/first' },
+        { id: 'third-1', url: '/third' },
+      ];
+
+      await expect(
+        storage.count({ url: ['IN', ['/first', '/third']] }, { group: ['url'] }),
+      ).resolves.toStrictEqual([
+        { url: '/first', count: 2 },
+        { url: '/third', count: 1 },
+      ]);
+    } finally {
+      globalThis.think = originalThink;
+    }
+  });
 });

--- a/packages/server/src/controller/comment.js
+++ b/packages/server/src/controller/comment.js
@@ -689,12 +689,17 @@ module.exports = class CommentController extends BaseRest {
       };
     }
 
-    if (Array.isArray(url) && (url.length > 1 || !this.ctx.state.deprecated)) {
-      const data = await this.modelInstance.select(where, {
-        field: ['url'],
-      });
+    if (Array.isArray(url) && url.length === 1) {
+      const count = await this.modelInstance.count(where);
 
-      return url.map((u) => data.filter(({ url }) => url === u).length);
+      return this.ctx.state.deprecated ? count : [count];
+    }
+
+    if (Array.isArray(url) && url.length > 1) {
+      const counts = await this.modelInstance.count(where, { group: ['url'] });
+      const countByUrl = new Map(counts.map(({ url, count }) => [url, count]));
+
+      return url.map((item) => countByUrl.get(item) ?? 0);
     }
     const data = await this.modelInstance.count(where);
 

--- a/packages/server/src/service/storage/github.js
+++ b/packages/server/src/service/storage/github.js
@@ -320,21 +320,19 @@ module.exports = class GithubStorage extends Base {
 
     const counts = {};
 
-    // FIXME: The loop is weird @lizheming
-    // oxlint-disable-next-line typescript/prefer-for-of
-    for (let i = 0; i < data.length; i++) {
-      const key = group.map((field) => data[field]).join(',');
+    for (const item of data) {
+      const key = group.map((field) => item[field]).join(',');
 
       if (!counts[key]) {
         counts[key] = { count: 0 };
         group.forEach((field) => {
-          counts[key][field] = data[field];
+          counts[key][field] = item[field];
         });
       }
       counts[key].count += 1;
     }
 
-    return Object.keys(counts);
+    return Object.values(counts);
   }
 
   async add(


### PR DESCRIPTION
## What changed

- uses a scalar storage `count()` for the modern single-URL count response
- uses grouped storage counts for multiple URLs
- maps grouped results back to the requested URL order and fills missing URLs with zero
- preserves the deprecated API's scalar response shape
- adds API-level regression tests for single and multiple URLs

## Why

The current modern count endpoint selects every matching `url` (plus the SQL adapter's implicit `id`) and counts rows in JavaScript. In the #3678 Supabase query snapshot this query ran 29,747 times and returned 40,587,484 rows—about 1,364 rows per request—to compute one or a few integers.

SQL, MongoDB, and CloudBase already expose storage-side scalar/grouped count operations, so the response can be computed without transferring comment rows to the serverless function.

## Validation

- `pnpm vitest run packages/server/__tests__` — 35 tests passed
- focused lint and formatting checks passed

Fixes the comment-count portion of #3678.
