### PR TITLE
perf(postgresql): add comment query indexes

### DIFF
--- a/assets/waline.pgsql
+++ b/assets/waline.pgsql
@@ -28,7 +28,7 @@ CREATE INDEX idx_comment_root_pagination ON wl_comment (
   sticky DESC NULLS LAST,
   insertedAt DESC,
   id DESC
-) WHERE rid IS NULL AND status NOT IN ('waiting', 'spam');
+) WHERE rid IS NULL;
 
 
 CREATE SEQUENCE wl_counter_seq;

--- a/assets/waline.pgsql
+++ b/assets/waline.pgsql
@@ -22,6 +22,14 @@ CREATE TABLE wl_comment (
   PRIMARY KEY (id)
 ) ;
 
+CREATE INDEX idx_comment_url_rid ON wl_comment (url, rid);
+CREATE INDEX idx_comment_root_pagination ON wl_comment (
+  url,
+  sticky DESC NULLS LAST,
+  insertedAt DESC,
+  id DESC
+) WHERE rid IS NULL AND status NOT IN ('waiting', 'spam');
+
 
 CREATE SEQUENCE wl_counter_seq;
 

--- a/assets/waline.pgsql.indexes
+++ b/assets/waline.pgsql.indexes
@@ -1,0 +1,10 @@
+-- Run this file once for an existing PostgreSQL Waline database.
+-- Replace wl_comment if a custom PG_PREFIX is in use.
+
+CREATE INDEX IF NOT EXISTS idx_comment_url_rid ON wl_comment (url, rid);
+CREATE INDEX IF NOT EXISTS idx_comment_root_pagination ON wl_comment (
+  url,
+  sticky DESC NULLS LAST,
+  insertedAt DESC,
+  id DESC
+) WHERE rid IS NULL AND status NOT IN ('waiting', 'spam');

--- a/assets/waline.pgsql.indexes
+++ b/assets/waline.pgsql.indexes
@@ -7,4 +7,4 @@ CREATE INDEX IF NOT EXISTS idx_comment_root_pagination ON wl_comment (
   sticky DESC NULLS LAST,
   insertedAt DESC,
   id DESC
-) WHERE rid IS NULL AND status NOT IN ('waiting', 'spam');
+) WHERE rid IS NULL;

--- a/docs/src/en/guide/database.md
+++ b/docs/src/en/guide/database.md
@@ -86,6 +86,8 @@ Download [waline.sqlite](https://github.com/walinejs/waline/blob/main/assets/wal
 
 [Supabase](https://supabase.com) and [Neon](https://neon.tech/home) offer a free 512M database, while [Tembo](https://tembo.io/) provides 10G PG database support for free. Same as MySQL, you need to import [waline.pgsql](https://github.com/walinejs/waline/blob/main/assets/waline.pgsql) to create table and table structure before using PostgreSQL.
 
+For a database created before the comment query indexes were added, also run [waline.pgsql.indexes](https://github.com/walinejs/waline/blob/main/assets/waline.pgsql.indexes) once. If you use a custom `PG_PREFIX`, replace `wl_comment` in the script with the actual table name first.
+
 | Environment Variable | Required | Default   | Description                         |
 | -------------------- | -------- | --------- | ----------------------------------- |
 | `PG_DB`              | ✅       |           | PostgreSQL database name            |

--- a/docs/src/guide/database.md
+++ b/docs/src/guide/database.md
@@ -88,6 +88,8 @@ MONGO_OPT_SSL=true
 
 同 MySQL，使用 PostgreSQL 也需要先导入 [waline.pgsql](https://github.com/walinejs/waline/blob/main/assets/waline.pgsql) 创建好表和表结构。之后在项目中配置如下环境变量。
 
+如果数据库是在评论查询索引加入前创建的，请额外执行一次 [waline.pgsql.indexes](https://github.com/walinejs/waline/blob/main/assets/waline.pgsql.indexes)。使用了自定义 `PG_PREFIX` 时，需要先将脚本中的 `wl_comment` 替换为实际表名。
+
 | 环境变量名称        | 必填 | 默认值    | 备注                                |
 | ------------------- | ---- | --------- | ----------------------------------- |
 | `PG_DB`             | ✅   |           | PostgreSQL 数据库库名               |


### PR DESCRIPTION
## What changed

- adds a general `(url, rid)` index for URL counts, root filtering, and current-page child lookups
- adds a root-pagination index matching sticky/time/ID ordering and restricted to root rows
- includes both indexes in the fresh PostgreSQL schema
- adds an idempotent `waline.pgsql.indexes` script for existing databases
- documents how existing PostgreSQL users and custom `PG_PREFIX` users apply the migration

## Why

The PostgreSQL schema currently has no secondary indexes on `wl_comment`. The Supabase query snapshot in #3678 recommends an index beginning with `url`, and the database-paginated list also needs efficient root filtering and default ordering.

The root index intentionally does not include the parameterized status predicate, so PostgreSQL can reuse it with prepared/generic plans and for administrator or logged-in visibility rules.

These indexes reduce scans and sorting. The pagination and count PRs are what reduce returned rows and egress; this PR complements them by reducing database work and latency.

## Validation

- Markdown documentation lint passed
- SQL and repository diffs pass whitespace validation
- index filtering and ordering match root-comment pagination (`rid IS NULL`, sticky/time/ID order)

Related to #3678.
