### PR TITLE
fix(server): skip notification when comment is marked as spam

### DIFF
--- a/packages/server/__tests__/notify-spam.spec.js
+++ b/packages/server/__tests__/notify-spam.spec.js
@@ -1,0 +1,104 @@
+// oxlint-disable vitest/no-hooks
+import http from 'node:http';
+import { createRequire } from 'node:module';
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+process.env.SQLITE_PATH = `/tmp/test-waline-notify-spam-${process.pid}.sqlite`;
+process.env.JWT_TOKEN = 'test-jwt-secret';
+process.env.AKISMET_KEY = 'false';
+process.env.AUTHOR_EMAIL = 'owner@example.com';
+
+const require = createRequire(import.meta.url);
+const main = require('../index.js');
+
+const commentAdd = vi.fn();
+const commentSelect = vi.fn();
+
+const handler = main({
+  forbiddenWords: ['spam-ad-keyword'],
+  customModel: (modelName) => {
+    if (modelName === 'Comment') {
+      return { add: commentAdd, select: commentSelect };
+    }
+
+    if (modelName === 'Users') {
+      return { select: async () => [] };
+    }
+  },
+});
+
+const NotifyService = require('../src/service/notify.js');
+const notifyRun = vi.spyOn(NotifyService.prototype, 'run').mockResolvedValue();
+
+describe('comment notification for spam', () => {
+  let server;
+  let port;
+
+  beforeAll(async () => {
+    server = http.createServer(handler);
+    await new Promise((resolve) => {
+      server.listen(0, resolve);
+    });
+    ({ port } = server.address());
+  });
+
+  beforeEach(() => {
+    commentAdd.mockReset();
+    commentSelect.mockReset();
+    notifyRun.mockClear();
+    commentSelect.mockResolvedValue([]);
+    commentAdd.mockImplementation(async (data) => ({
+      objectId: 'comment-1',
+      ...data,
+    }));
+  });
+
+  afterAll(async () => {
+    delete process.env.SQLITE_PATH;
+    delete process.env.JWT_TOKEN;
+    delete process.env.AKISMET_KEY;
+    delete process.env.AUTHOR_EMAIL;
+    notifyRun.mockRestore();
+    await new Promise((resolve) => {
+      server.close(resolve);
+    });
+  });
+
+  const postComment = (body) =>
+    fetch(`http://localhost:${port}/api/comment`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    }).then((response) => response.json());
+
+  it('notifies the author for a normal comment', async () => {
+    const body = await postComment({
+      nick: 'reader',
+      mail: 'reader@example.com',
+      comment: 'Nice post',
+      url: '/posts/hello/',
+    });
+
+    expect(body.errno).toBe(0);
+    expect(commentAdd).toHaveBeenCalledOnce();
+    expect(commentAdd.mock.calls[0][0].status).toBe('approved');
+    expect(notifyRun).toHaveBeenCalledOnce();
+  });
+
+  it('does not notify the author when a comment is stored as spam', async () => {
+    const body = await postComment({
+      nick: 'spammer',
+      mail: 'spam@example.com',
+      comment: 'Buy spam-ad-keyword now',
+      url: '/posts/hello/',
+    });
+
+    expect(body.errno).toBe(0);
+    expect(commentAdd).toHaveBeenCalledOnce();
+    expect(commentAdd.mock.calls[0][0].status).toBe('spam');
+    expect(notifyRun).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/controller/comment.js
+++ b/packages/server/src/controller/comment.js
@@ -250,7 +250,8 @@ module.exports = class CommentController extends BaseRest {
         )
       : undefined;
 
-    if (comment.status !== 'spam') {
+    // `comment` is the raw markdown text from the request body.
+    if (resp.status !== 'spam') {
       const notify = this.service('notify', this);
 
       await notify.run(

--- a/packages/server/src/controller/comment.js
+++ b/packages/server/src/controller/comment.js
@@ -250,8 +250,7 @@ module.exports = class CommentController extends BaseRest {
         )
       : undefined;
 
-    // `comment` is the raw markdown text from the request body.
-    if (resp.status !== 'spam') {
+    if (data.status !== 'spam') {
       const notify = this.service('notify', this);
 
       await notify.run(


### PR DESCRIPTION
## Summary

Spam comments still triggered author notifications because the post-save guard checked the wrong variable.

In `postAction()`, the request body is unpacked as:

```js
const { comment, link, mail, nick, pid, rid, ua, url, at } = this.post();
```

Here `comment` is the raw markdown **text**, not the comment record. The old notify condition was:

```js
if (comment.status !== 'spam')
```

A string has no `status`, so that check was always true. Comments marked as `spam` by Akismet or `forbiddenWords` were hidden from the site, but the owner still got an email for every one.

Akismet / keyword filtering write the result onto `data.status` before `modelInstance.add(data)`. This PR checks `data.status !== 'spam'` instead. `add()` should persist the same status, so `resp.status` would normally match; `data.status` is the field this function actually sets.

This is the same behavior reported in #857. That issue was closed after the existing `comment.status` check was treated as correct; the variable name is what made it look that way.

Waiting comments are unchanged and still notify the author.

## Test plan

- [x] Added `packages/server/__tests__/notify-spam.spec.js`
  - approved comment still calls `notify.run`
  - keyword-marked spam comment is stored as `spam` and does **not** call `notify.run`
- [ ] Confirm locally with `pnpm test -- packages/server/__tests__/notify-spam.spec.js` from the repo root